### PR TITLE
Start first-level lists flush at the body text edge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,16 @@ When you need a tool not in `devenv.nix`:
 
 See `.claude/skills/nix-tools.md` for detailed examples and patterns.
 
+### Sandboxes without nix
+
+Cloud sandboxes (e.g. Claude Code on the web) have neither nix nor
+devenv, and their network policy may block installing nix. Use apt
+instead — `sudo apt-get update`, then install the TeX Live packages,
+latexmk, poppler-utils, pandoc and librsvg2-bin — and replicate the
+`make markdown` flake pipeline manually with pandoc + latexmk. See
+"Cloud Sandbox" in `CLAUDE.md` for the exact commands and the
+parity-check caveat that comes with the different toolchain versions.
+
 ## File Structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,50 @@ To run a one-off command in the devenv shell without entering it:
 devenv shell --no-eval-cache -- latexmk -pdf myfile.tex
 ```
 
+## Cloud Sandbox (Claude Code on the web)
+
+Remote sandbox sessions run in a plain Ubuntu container: `nix`,
+`devenv` and TeX are **not** installed, and the network policy blocks
+`nixos.org` (HTTP 403 `host_not_allowed`), so nix cannot be installed
+either. The nix-based instructions above don't apply there — fall back
+to apt, which does work:
+
+```bash
+sudo apt-get update   # required first: the baked-in index is stale (404s)
+sudo apt-get install -y texlive-latex-recommended texlive-latex-extra \
+  texlive-lang-european latexmk poppler-utils pandoc librsvg2-bin
+```
+
+(`apt-get update` reports a 403 for an unrelated `ondrej/php` PPA —
+harmless, ignore it.)
+
+After that `make examples` works directly. `make markdown` does not
+(it needs `nix run`), so replicate the flake's pipeline (see
+`flake.nix`) manually per file:
+
+```bash
+input="$(realpath examples/markdown/esimerkki-poytakirja.md)"
+dir="$(dirname "$input")"; base="$(basename "$input" .md)"
+tmp="$(mktemp -d)"; export SFS_2487_TMPDIR="$tmp"
+(cd "$dir" && pandoc --standalone \
+  --template "$PWD/../../pandoc/sfs-2487-2024.latex" \
+  --lua-filter "$PWD/../../pandoc/sfs-2487-2024.lua" \
+  --output "$tmp/document.tex" "$input" && \
+ TEXINPUTS="$dir:$PWD/../..:" latexmk -pdf -interaction=nonstopmode \
+   -quiet -output-directory="$tmp" "$tmp/document.tex" && \
+ cp "$tmp/document.pdf" "$dir/$base.pdf")
+rm -rf "$tmp"
+```
+
+**Parity-check caveat:** Ubuntu's TeX Live 2023 and pandoc 3.1.3 differ
+from the flake's pinned toolchain, so the `pdftotext -layout` parity
+diff shows small whitespace-only differences in some pairs (e.g.
+`esimerkki-poytakirja`, `esimerkki-raportti`). Before blaming your
+change, rebuild from a pristine checkout (`git stash`) and diff that
+baseline — if the baseline shows the same differences, they are
+environmental, not regressions. `pdftotext -bbox` position checks
+(en dash / item numbers at 121.89 pt, etc.) remain reliable.
+
 ## Verification Workflow
 
 Before completing a task:


### PR DESCRIPTION
## Summary

enumitem's default `leftmargin` pushed first-level `itemize` and `enumerate` lists right of the 2,3 cm body indent the text already occupies — a double indent clause 6.5.3 does not call for. `leftmargin=*` on level 1 puts the en-dash marker and item numbers flush at the body text edge; nested levels keep their relative indentation.

- `sfs-2487-2024.cls`: add `\setlist[itemize,1]{leftmargin=*}` and `\setlist[enumerate,1]{leftmargin=*}` after the existing type-wide settings
- No pandoc changes needed — the Markdown front end emits plain `itemize`/`enumerate`, so the class change covers both formats
- Updated list-layout wording in `docs/latex.md`, `docs/standard.md` (clause 6.5.3 row) and `sfs-2487-2024-doc.tex`
- Also documents the apt fallback for nix-less cloud sandboxes in `CLAUDE.md`/`AGENTS.md` (this session's environment could not install nix)

## Verification

- All 5 LaTeX examples, all 5 Markdown twins and the CTAN doc build cleanly
- `pdftotext -bbox`: the en dash in `esimerkki-poytakirja` and the item numbers in `esimerkki-kayttoohje` now start at exactly 121.89 pt (43 mm body indent) in both the LaTeX and Markdown builds (previously ~150 pt)
- Markdown/LaTeX parity: 3 of 5 pairs diff-clean; `poytakirja`/`raportti` show whitespace-only `pdftotext -layout` diffs that a pristine-checkout baseline build reproduces identically — artifacts of the sandbox's TeX Live 2023/pandoc 3.1.3 versus the pinned flake toolchain, not regressions. Worth re-running `make markdown` + the parity diff in the real devenv.
- The spec PDF was not present in this environment, so no visual comparison against Liite A — the bbox measurement is the objective check that was available.

https://claude.ai/code/session_01Nq61DvVqXpV1AxAcUoMWmG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq61DvVqXpV1AxAcUoMWmG)_