### PR TITLE
Replace sansserif option with three-way font option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ SFS 2487 is a Finnish standard specifying the layout, information areas and meta
 
 - **`sfs-2487-2024.cls`** — Complete implementation of SFS 2487:2024
   - Information areas on the 2,3 cm column grid, basic metadata 9,2 cm from the left margin, `1 (2)` page numbering, metadata repeated as a header from page 2 on
-  - Class options: `agenda` (trailing-period heading numbers), `sansserif` (Helvetica look), plus pass-through `article` options such as `12pt`
+  - Class options: `serif` (Palatino), `sans-serif` (Helvetica, default), `monospace` (Courier), `agenda` (trailing-period heading numbers), plus pass-through `article` options such as `12pt`
   - Verified against the spec PDF; maintained, not under construction
 
 ## Spec PDF
@@ -121,7 +121,8 @@ Pöytäkirjat/
 │   │   ├── esimerkki-tarjous.tex      # Example: quotation (spec Liite B)
 │   │   ├── esimerkki-kokouskutsu.tex  # Example: meeting invitation ([agenda])
 │   │   ├── esimerkki-raportti.tex     # Example: multi-page report (TOC, table, footnote)
-│   │   └── esimerkki-kayttoohje.tex   # Example: manual with captioned figures ([sansserif])
+│   │   ├── esimerkki-kayttoohje.tex   # Example: manual with captioned figures ([sans-serif])
+│   │   └── esimerkki-monospace.tex    # Example: memo with Courier typewriter font ([monospace])
 │   ├── markdown/
 │   │   └── esimerkki-*.md      # Markdown twins of the LaTeX examples
 │   ├── logo-organisaatio.tex   # Invented TikZ logo: Organisaatio Oy

--- a/devenv.nix
+++ b/devenv.nix
@@ -11,6 +11,7 @@
         scheme-basic
         babel-finnish
         caption
+        courier
         enumitem
         everyshi
         helvetic

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,7 +11,8 @@ below are built from this very revision of the class.
 | `esimerkki-tarjous` | The standard's own Liite B example: quotation with document id, extra metadata, recipient area, closing greeting (6.5.4) and handwritten signature (6.6.1) | [PDF](pdf/latex/esimerkki-tarjous.pdf) | [PDF](pdf/markdown/esimerkki-tarjous.pdf) |
 | `esimerkki-kokouskutsu` | Meeting invitation with an agenda, using the `agenda` option's `1.` numbering and an unnumbered *Esityslista* heading | [PDF](pdf/latex/esimerkki-kokouskutsu.pdf) | [PDF](pdf/markdown/esimerkki-kokouskutsu.pdf) |
 | `esimerkki-raportti` | Multi-page report: table of contents (6.10), table with its caption above and a bold header row (6.5.1), footnote (6.9), three heading levels | [PDF](pdf/latex/esimerkki-raportti.pdf) | [PDF](pdf/markdown/esimerkki-raportti.pdf) |
-| `esimerkki-kayttoohje` | `sansserif` manual with captioned figures in the text flow (6.5.2) and numbered step lists | [PDF](pdf/latex/esimerkki-kayttoohje.pdf) | [PDF](pdf/markdown/esimerkki-kayttoohje.pdf) |
+| `esimerkki-kayttoohje` | `sans-serif` manual with captioned figures in the text flow (6.5.2) and numbered step lists | [PDF](pdf/latex/esimerkki-kayttoohje.pdf) | [PDF](pdf/markdown/esimerkki-kayttoohje.pdf) |
+| `esimerkki-monospace` | `monospace` memo demonstrating the Courier typewriter font | [PDF](pdf/latex/esimerkki-monospace.pdf) | [PDF](pdf/markdown/esimerkki-monospace.pdf) |
 
 `esimerkki-poytakirja` and `esimerkki-tarjous` replicate the standard's
 own model documents (Liite A and B in SFS 2487:2024), so their output

--- a/docs/latex.md
+++ b/docs/latex.md
@@ -46,12 +46,13 @@ these same commands.
 
 | Option | Effect |
 |---|---|
-| *(default)* | Palatino body font at 11 pt, headings bold, numbered `1 Otsikko` |
+| *(default)* / `sans-serif` | Helvetica-like sans serif throughout, matching the look of the standard's own example renderings |
+| `serif` | Palatino body font (classic serif look) |
+| `monospace` | Courier typewriter font throughout |
 | `agenda` | Meeting-agenda numbering with a trailing period, `1. Otsikko` (an established alternative the standard permits, 6.4.1). Headings stay bold either way — clause 6.4 requires bold or a larger font size. |
-| `sansserif` | Helvetica-like sans serif throughout, matching the look of the standard's own example renderings |
 | `12pt` | Larger base font size (any other `article` option is passed through as well) |
 
-Options combine, e.g. `\documentclass[agenda,sansserif]{sfs-2487-2024}`.
+Options combine, e.g. `\documentclass[agenda,serif]{sfs-2487-2024}`.
 
 ## Metadata commands (preamble)
 

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -70,7 +70,7 @@ attachments: [Yhteenveto asiakaspalautteesta]   # Liitteet
 distribution: [Digiprojektin ohjausryhmä]       # Jakelu
 forinformation: [Johtoryhmä]                    # Tiedoksi
 agenda: true                         # class options …
-sansserif: true
+font: sans-serif                     # serif / sans-serif (default) / monospace
 fontsize: 12pt
 toc: true                            # \tableofcontents after the title
 ---

--- a/examples/latex/esimerkki-kayttoohje.tex
+++ b/examples/latex/esimerkki-kayttoohje.tex
@@ -1,8 +1,8 @@
-\documentclass[sansserif]{sfs-2487-2024}
+\documentclass[sans-serif]{sfs-2487-2024}
 
 % Käyttöohje, jossa on kuvatekstillisiä kuvia tekstin tasossa ja tekstin
 % sisennyskohdassa (6.5.2) sekä numeroituja vaiheluetteloita (6.5.3).
-% Vaihtoehto [sansserif] latoo asiakirjan groteskilla, joka vastaa
+% Vaihtoehto [sans-serif] latoo asiakirjan groteskilla, joka vastaa
 % standardin omien esimerkkien ulkoasua.
 
 \logo{\includegraphics{logo-organisaatio}}

--- a/examples/latex/esimerkki-monospace.tex
+++ b/examples/latex/esimerkki-monospace.tex
@@ -1,0 +1,50 @@
+\documentclass[monospace]{sfs-2487-2024}
+
+% Muistio, joka on laadittu tasavälisellä kirjasinlajilla (Courier).
+% Vaihtoehto [monospace] latoo asiakirjan kirjoituskonetyylisesti.
+
+\logo{\includegraphics{logo-organisaatio}}
+\doctype{Muistio}
+\date{5.6.2024}
+\author{Tero Testi}
+
+\subject{Tietojärjestelmä}
+\title{Käyttöoikeuksien hallinta}
+
+\contactinfo{Organisaatio Oy}{%
+  Katuosoite\\
+  Postinumero Postitoimipaikka\\
+  it@organisaatio.fi}
+
+\begin{document}
+
+\maketitle
+
+\marginlabel{Vastaanottajat}
+
+Järjestelmänvalvojat
+
+\section{Nykytilanne}
+
+Käyttöoikeuksia hallitaan tällä hetkellä manuaalisesti jokaisen
+järjestelmän omassa hallintarajapinnassa. Tunnuksia luodaan
+pyydettäessä sähköpostilla, eikä vanhentuneita tunnuksia poisteta
+järjestelmällisesti.
+
+\section{Ehdotus}
+
+Otetaan käyttöön keskitetty identiteetinhallintajärjestelmä. Se
+yhdistää kaikki organisaation järjestelmät yhteen hallintapisteeseen
+ja mahdollistaa automaattisen tunnusten elinkaarihallinnan.
+
+\begin{enumerate}
+  \item Valitaan järjestelmä ja kilpailutetaan toimittajat.
+  \item Toteutetaan pilotti kahdelle järjestelmälle.
+  \item Laajennetaan käyttöönotto koko organisaatioon.
+\end{enumerate}
+
+\forinformation{Johtoryhmä}
+
+\makecontactinfo
+
+\end{document}

--- a/examples/markdown/esimerkki-kayttoohje.md
+++ b/examples/markdown/esimerkki-kayttoohje.md
@@ -1,7 +1,7 @@
 ---
 # Markdown-versio ../latex/esimerkki-kayttoohje.tex-asiakirjasta:
 # käyttöohje, jossa on kuvatekstillisiä kuvia tekstin tasossa (6.5.2)
-# ja numeroituja vaiheluetteloita (6.5.3). Vaihtoehto "sansserif: true"
+# ja numeroituja vaiheluetteloita (6.5.3). Vaihtoehto "font: sans-serif"
 # latoo asiakirjan groteskilla, joka vastaa standardin omien esimerkkien
 # ulkoasua.
 doctype: Käyttöohje
@@ -10,7 +10,7 @@ author: Virve Virtanen
 subject: Graafinen ohjeisto
 title: Logon käyttö asiakirjoissa
 logo: ../logo-organisaatio.pdf
-sansserif: true
+font: sans-serif
 contact:
   name: Organisaatio Oy
   lines:

--- a/examples/markdown/esimerkki-monospace.md
+++ b/examples/markdown/esimerkki-monospace.md
@@ -1,0 +1,41 @@
+---
+# Markdown-versio ../latex/esimerkki-monospace.tex-asiakirjasta:
+# muistio tasavälisellä kirjasinlajilla (Courier). Vaihtoehto
+# "font: monospace" latoo asiakirjan kirjoituskonetyylisesti.
+doctype: Muistio
+date: 5.6.2024
+author: Tero Testi
+subject: Tietojärjestelmä
+title: Käyttöoikeuksien hallinta
+logo: ../logo-organisaatio.pdf
+font: monospace
+contact:
+  name: Organisaatio Oy
+  lines:
+    - Katuosoite
+    - Postinumero Postitoimipaikka
+    - it@organisaatio.fi
+forinformation:
+  - Johtoryhmä
+endmatter-newpage: false
+---
+
+Vastaanottajat
+:   Järjestelmänvalvojat
+
+# Nykytilanne
+
+Käyttöoikeuksia hallitaan tällä hetkellä manuaalisesti jokaisen
+järjestelmän omassa hallintarajapinnassa. Tunnuksia luodaan
+pyydettäessä sähköpostilla, eikä vanhentuneita tunnuksia poisteta
+järjestelmällisesti.
+
+# Ehdotus
+
+Otetaan käyttöön keskitetty identiteetinhallintajärjestelmä. Se
+yhdistää kaikki organisaation järjestelmät yhteen hallintapisteeseen
+ja mahdollistaa automaattisen tunnusten elinkaarihallinnan.
+
+1. Valitaan järjestelmä ja kilpailutetaan toimittajat.
+2. Toteutetaan pilotti kahdelle järjestelmälle.
+3. Laajennetaan käyttöönotto koko organisaatioon.

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         texliveEnv = pkgs.texlive.combine {
           inherit (pkgs.texlive)
             scheme-basic
-            babel-finnish caption enumitem everyshi helvetic hyperref
+            babel-finnish caption courier enumitem everyshi helvetic hyperref
             hyphen-finnish latex latexmk mathpazo metafont microtype
             pgf preview ragged2e totpages xcolor
             booktabs soul upquote fancyvrb framed;

--- a/pandoc/sfs-2487-2024.latex
+++ b/pandoc/sfs-2487-2024.latex
@@ -5,7 +5,7 @@
 % only support for pandoc-generated body code is added here. Multi-line
 % fields (recipient, extrametadata, contact.lines, attachments, …) are YAML
 % lists joined with line breaks.
-\documentclass[$if(fontsize)$$fontsize$,$endif$$if(agenda)$agenda,$endif$$if(sansserif)$sansserif,$endif$$for(classoption)$$classoption$,$endfor$]{sfs-2487-2024}
+\documentclass[$if(fontsize)$$fontsize$,$endif$$if(agenda)$agenda,$endif$$if(font)$$font$,$endif$$for(classoption)$$classoption$,$endfor$]{sfs-2487-2024}
 
 % Macros that pandoc-generated body code may reference
 \providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}

--- a/sfs-2487-2024-doc.tex
+++ b/sfs-2487-2024-doc.tex
@@ -101,19 +101,20 @@ needed for the total page count in the ``1~(2)'' page number.
 \section{Class options}
 
 \begin{description}
-\item[(default)] Palatino body font at 11\,pt, bold headings numbered
-  \mbox{``1 Otsikko''}.
+\item[(default), sans-serif] Helvetica-like sans serif at 11\,pt, bold
+  headings numbered \mbox{``1 Otsikko''}, matching the look of the
+  standard's own example renderings.
+\item[serif] Palatino body font instead of Helvetica.
+\item[monospace] Courier typewriter font throughout.
 \item[agenda] Meeting-agenda heading numbering with a trailing period,
   \mbox{``1. Otsikko''} --- an established alternative the standard
   permits (clause 6.4.1). Headings stay bold either way, as clause 6.4
   requires bold or a larger font size.
-\item[sansserif] A Helvetica-like sans serif throughout, matching the
-  look of the standard's own example renderings.
 \item[12pt, \ldots] Any other option is passed through to
   \textsf{article}, e.g.\ a larger base font size.
 \end{description}
 
-Options combine: \verb|\documentclass[agenda,sansserif]{sfs-2487-2024}|.
+Options combine: \verb|\documentclass[agenda,serif]{sfs-2487-2024}|.
 
 \section{Metadata commands}
 
@@ -331,7 +332,9 @@ The package ships example documents exercising the class API:
 \item[esimerkki-raportti.tex] A multi-page report with a table of
   contents, a table and a footnote.
 \item[esimerkki-kayttoohje.tex] A manual with captioned figures, using
-  the \opt{sansserif} class option.
+  the \opt{sans-serif} class option.
+\item[esimerkki-monospace.tex] A memo using the \opt{monospace} class
+  option for a Courier typewriter look.
 \item[logo-*.tex] Invented TikZ logos used by the examples.
 \end{description}
 

--- a/sfs-2487-2024.cls
+++ b/sfs-2487-2024.cls
@@ -27,13 +27,18 @@
 % the standard also permits as an established convention (6.4.1). Headings
 % stay bold either way, as 6.4 requires bold or a larger font size.
 %
-% [sansserif] typesets the document in a Helvetica-like sans serif, matching
-% the look of the standard's own example renderings, instead of Palatino.
+% [serif] typesets the document in Palatino (serif).
+% [sans-serif] (default) typesets in a Helvetica-like sans serif, matching
+%   the look of the standard's own example renderings.
+% [monospace] typesets in Courier (typewriter look).
 
 \newif\ifsfs@agenda
 \DeclareOption{agenda}{\sfs@agendatrue}
-\newif\ifsfs@sans
-\DeclareOption{sansserif}{\sfs@sanstrue}
+\newif\ifsfs@font@serif
+\newif\ifsfs@font@mono
+\DeclareOption{serif}{\sfs@font@seriftrue}
+\DeclareOption{sans-serif}{}
+\DeclareOption{monospace}{\sfs@font@monotrue}
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
 \ProcessOptions\relax
 
@@ -43,12 +48,15 @@
 % Typeface and layout
 %
 
-\ifsfs@sans
+\ifsfs@font@serif
+  \RequirePackage{mathpazo}
+\else\ifsfs@font@mono
+  \RequirePackage{courier}
+  \renewcommand{\familydefault}{\ttdefault}
+\else
   \RequirePackage{helvet}
   \renewcommand{\familydefault}{\sfdefault}
-\else
-  \RequirePackage{mathpazo}
-\fi
+\fi\fi
 \RequirePackage{microtype}
 \RequirePackage{graphicx}
 \RequirePackage{ragged2e}


### PR DESCRIPTION
Replace the binary [sansserif] class option and sansserif: true Markdown
frontmatter key with an explicit three-way font choice:

  [serif]      — Palatino (former non-sansserif default)
  [sans-serif] — Helvetica, now the default (former sansserif option)
  [monospace]  — Courier, new option

The Pandoc template now reads font: serif/sans-serif/monospace instead of
sansserif: true. Add courier to devenv.nix and flake.nix texliveEnv.

Add esimerkki-monospace (LaTeX + Markdown) as a new example demonstrating
the monospace option. Update all docs, AGENTS.md, and sfs-2487-2024-doc.tex.

https://claude.ai/code/session_01VUKXeLvuAGBA3e62cd5nxd