### PR TITLE
docs: Target generic LaTeX users in the LaTeX writing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ Puheenjohtaja avasi kokouksen ja toivotti kaikki tervetulleiksi.
 \end{document}
 ```
 
+Drop [`sfs-2487-2024.cls`](sfs-2487-2024.cls) next to the document (or
+install it, see below) and build with any TeX distribution:
+
+```bash
+latexmk -pdf mydocument.tex
+```
+
 See [Writing in LaTeX](docs/latex.md) for the complete command reference.
 
 ## Examples
@@ -103,8 +110,16 @@ make markdown     # build every examples/markdown/esimerkki-*.md via the flake
 
 ## Installing the class
 
-For use outside this repository, the class can be installed into your
-own TEXMF tree with [l3build](https://ctan.org/pkg/l3build):
+For use outside this repository, copy the class into your own TEXMF
+tree:
+
+```bash
+mkdir -p ~/texmf/tex/latex/sfs-2487-2024
+cp sfs-2487-2024.cls ~/texmf/tex/latex/sfs-2487-2024/
+```
+
+or, from a clone of the repository, let
+[l3build](https://ctan.org/pkg/l3build) do the same:
 
 ```bash
 l3build install     # copies sfs-2487-2024.cls into ~/texmf

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -17,7 +17,8 @@ below are built from this very revision of the class.
 own model documents (Liite A and B in SFS 2487:2024), so their output
 can be compared against the specification figures directly.
 
-Build the examples yourself with `make examples` (LaTeX) and
+From a checkout of the repository, build the examples yourself with
+`make examples` (LaTeX) and
 `make markdown` (Markdown via the nix flake). The invented sample
 graphics the examples use — the *Organisaatio Oy* and *Oy Firma Ab*
 logos and the logo clearance-area figure — are drawn with TikZ in

--- a/docs/latex.md
+++ b/docs/latex.md
@@ -29,14 +29,35 @@ Puheenjohtaja avasi kokouksen ja toivotti kaikki tervetulleiksi.
 \end{document}
 ```
 
-Build with:
+## Getting the class
+
+The class is a single file. Download
+[`sfs-2487-2024.cls`](https://github.com/datakurre/vakioasiakirja/raw/main/sfs-2487-2024.cls)
+into the same directory as your document — LaTeX picks up classes from
+the current directory. To make it available to every document instead,
+install it into your personal TEXMF tree:
 
 ```bash
-make TEXFILE=mydocument build
+mkdir -p ~/texmf/tex/latex/sfs-2487-2024
+cp sfs-2487-2024.cls ~/texmf/tex/latex/sfs-2487-2024/
 ```
 
-(or `latexmk -pdf mydocument.tex` inside `devenv shell`; latexmk runs the
-extra pass needed for the total page count automatically).
+(or, from a clone of the repository, run
+[`l3build install`](https://ctan.org/pkg/l3build)).
+
+The class needs only packages found in any reasonably complete TeX
+distribution (TeX Live, MacTeX, MiKTeX); on Debian/Ubuntu the packages
+`texlive-latex-recommended`, `texlive-latex-extra` and
+`texlive-lang-european` suffice.
+
+## Building
+
+```bash
+latexmk -pdf mydocument.tex
+```
+
+latexmk reruns pdflatex as needed for the `1 (2)` total page count;
+with plain `pdflatex`, compile twice.
 
 The sections below are the LaTeX reference; the
 [Markdown frontmatter keys and body constructs](markdown.md) map onto


### PR DESCRIPTION
Replace the repository-only build instructions (make TEXFILE=…,
devenv shell) in docs/latex.md with what a standalone user needs:
where to get sfs-2487-2024.cls (next to the document or in the
personal TEXMF tree), which TeX distribution packages suffice, and
plain latexmk -pdf as the build command. Make README's LaTeX quick
start self-contained with the same command, show the no-l3build
install path, and mark the examples build instructions as
repository-scoped.

https://claude.ai/code/session_01Rv5Hbghe4awNSGNE29BFCx