### PR TITLE
Merge Markdown frontmatter booleans into a features list

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,29 @@
+name: smoke-test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Newer pushes to the same PR supersede the running build.
+concurrency:
+  group: smoke-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # make docs builds every LaTeX example, every Markdown twin via the
+      # flake, and the mkdocs site — the full build surface, same as the
+      # docs workflow but without deploying anything.
+      - name: Build examples and documentation site
+        run: nix shell .#texliveEnv --command make docs

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -69,19 +69,30 @@ contact:                             # \contactinfo + \makecontactinfo at the en
 attachments: [Yhteenveto asiakaspalautteesta]   # Liitteet
 distribution: [Digiprojektin ohjausryhmä]       # Jakelu
 forinformation: [Johtoryhmä]                    # Tiedoksi
-agenda: true                         # class options …
 font: sans-serif                     # serif / sans-serif (default) / monospace
 fontsize: 12pt
-toc: true                            # \tableofcontents after the title
+features: [agenda, toc]              # optional features, see below
 ---
 ```
+
+The `features` key is a list of optional features to turn on:
+
+- `agenda` — the class's `agenda` option: heading numbers with a
+  trailing period (`1. Otsikko`), the established convention for
+  agendas and minutes (6.4.1)
+- `toc` — `\tableofcontents` right after the title
+- `endmatter-newpage` — start the end matter on a fresh page
+
+A `no-` prefix turns a feature off (`features: [no-endmatter-newpage]`);
+unknown feature names are an error.
 
 The attachment, distribution and for-information lists and the contact
 block are placed after the body in the standard's order. They start on a
 fresh page whenever any of the three lists is present (like the
-standard's pöytäkirja example); set `endmatter-newpage: false`/`true` to
-override. When they stay on the same page, the class separates them
-from the body with an extra paragraph gap.
+standard's pöytäkirja example); add `no-endmatter-newpage` (or
+`endmatter-newpage`) to `features:` to override. When they stay on the
+same page, the class separates them from the body with an extra
+paragraph gap.
 
 For a document in another language, renew the class's fixed strings via
 the `header-includes` key:

--- a/examples/markdown/esimerkki-kayttoohje.md
+++ b/examples/markdown/esimerkki-kayttoohje.md
@@ -19,7 +19,7 @@ contact:
     - viestinta@organisaatio.fi
 forinformation:
   - Viestintäosasto
-endmatter-newpage: false
+features: [no-endmatter-newpage]
 ---
 
 # Logon perusversio

--- a/examples/markdown/esimerkki-kokouskutsu.md
+++ b/examples/markdown/esimerkki-kokouskutsu.md
@@ -1,15 +1,16 @@
 ---
 # Markdown-versio ../latex/esimerkki-kokouskutsu.tex-asiakirjasta:
-# kokouskutsu esityslistoineen. Vaihtoehto "agenda: true" numeroi otsikot
-# loppupisteellisinä ("1. Otsikko"), mikä on standardin 6.4.1 salliman
-# vakiintuneen tavan mukaista esityslistoissa ja pöytäkirjoissa.
+# kokouskutsu esityslistoineen. Ominaisuus "features: [agenda]" numeroi
+# otsikot loppupisteellisinä ("1. Otsikko"), mikä on standardin 6.4.1
+# salliman vakiintuneen tavan mukaista esityslistoissa ja pöytäkirjoissa.
 doctype: Kokouskutsu
 date: 6.5.2024
 author: Virve Virtanen
 subject: Digiprojekti
 title: Projektiryhmän kokous 5/2024
 logo: ../logo-organisaatio.pdf
-agenda: true
+# Liitealueet jatkuvat samalla sivulla rungon perässä (vrt. .tex-versio).
+features: [agenda, no-endmatter-newpage]
 contact:
   name: Organisaatio Oy
   lines:
@@ -23,8 +24,6 @@ distribution:
   - Projektiryhmän jäsenet
 forinformation:
   - Johtoryhmä
-# Liitealueet jatkuvat samalla sivulla rungon perässä (vrt. .tex-versio).
-endmatter-newpage: false
 ---
 
 Projektiryhmän seuraava kokous pidetään maanantaina 13.5.2024

--- a/examples/markdown/esimerkki-monospace.md
+++ b/examples/markdown/esimerkki-monospace.md
@@ -17,7 +17,7 @@ contact:
     - it@organisaatio.fi
 forinformation:
   - Johtoryhmä
-endmatter-newpage: false
+features: [no-endmatter-newpage]
 ---
 
 Vastaanottajat

--- a/examples/markdown/esimerkki-raportti.md
+++ b/examples/markdown/esimerkki-raportti.md
@@ -12,7 +12,7 @@ keywords: [asiakaspalaute, kysely, digiprojekti]
 subject: Digiprojekti
 title: Asiakaspalautekyselyn tulokset 2024
 logo: ../logo-organisaatio.pdf
-toc: true
+features: [toc, no-endmatter-newpage]
 contact:
   name: Organisaatio Oy
   lines:
@@ -27,7 +27,6 @@ distribution:
   - Digiprojektin ohjausryhmä
 forinformation:
   - Johtoryhmä
-endmatter-newpage: false
 ---
 
 # Johdanto

--- a/pandoc/sfs-2487-2024.latex
+++ b/pandoc/sfs-2487-2024.latex
@@ -5,7 +5,7 @@
 % only support for pandoc-generated body code is added here. Multi-line
 % fields (recipient, extrametadata, contact.lines, attachments, …) are YAML
 % lists joined with line breaks.
-\documentclass[$if(fontsize)$$fontsize$,$endif$$if(agenda)$agenda,$endif$$if(font)$$font$,$endif$$for(classoption)$$classoption$,$endfor$]{sfs-2487-2024}
+\documentclass[$if(fontsize)$$fontsize$,$endif$$if(sfs-agenda)$agenda,$endif$$if(font)$$font$,$endif$$for(classoption)$$classoption$,$endfor$]{sfs-2487-2024}
 
 % Macros that pandoc-generated body code may reference
 \providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
@@ -77,11 +77,11 @@ $endif$
 
 \maketitle
 
-$if(toc)$
+$if(sfs-toc)$
 \tableofcontents
 $endif$
 $body$
-$if(endmatter-newpage)$
+$if(sfs-endmatter-newpage)$
 \clearpage
 $endif$
 $if(attachments)$

--- a/pandoc/sfs-2487-2024.lua
+++ b/pandoc/sfs-2487-2024.lua
@@ -7,9 +7,10 @@
 --   ::: esignatures             -> esignatures environment + \esignee
 --   ::: handsignature           -> \handsignature{line} per line
 -- and validates frontmatter (doctype/title required, logo image paths
--- wrapped in \includegraphics, at most three heading levels). SVG images
--- (logo or body) are converted to PDF with rsvg-convert, which the nix
--- flake provides; pdflatex cannot read SVG directly.
+-- wrapped in \includegraphics, the features list expanded into per-feature
+-- booleans, at most three heading levels). SVG images (logo or body) are
+-- converted to PDF with rsvg-convert, which the nix flake provides;
+-- pdflatex cannot read SVG directly.
 
 -- Render inlines as LaTeX so special characters survive the trip into
 -- raw \marginlabel/\esignee arguments.
@@ -89,6 +90,51 @@ local function lines_of(inlines)
   return lines
 end
 
+-- Optional features come in a single frontmatter list; the template cannot
+-- test list membership, so expand the tokens into per-feature sfs-* booleans
+-- the template reads. A 'no-' prefix turns a feature off — needed because
+-- endmatter-newpage defaults to true whenever attachments, distribution or
+-- forinformation are present (the pöytäkirja model document starts its end
+-- matter on a fresh page; contact info alone stays inline, as in the tarjous
+-- model document; the class itself separates inline end matter from the body
+-- by a paragraph gap).
+local feature_names = pandoc.List({'agenda', 'toc', 'endmatter-newpage'})
+
+local function parse_features(meta)
+  for _, name in ipairs(feature_names) do
+    if meta[name] ~= nil then
+      error(("sfs-2487-2024: metatieto '%s:' on korvattu features-" ..
+             "luettelolla (top-level key replaced by the features list): " ..
+             "kirjoita (write) features: [%s] tai (or) features: [no-%s]\n")
+            :format(name, name, name))
+    end
+  end
+  local features = {}
+  if meta.features ~= nil then
+    local list = meta.features
+    -- A bare scalar (features: agenda) arrives as MetaInlines, not MetaList.
+    if pandoc.utils.type(list) ~= 'List' then list = pandoc.List({list}) end
+    for _, item in ipairs(list) do
+      local token = pandoc.utils.stringify(item)
+      local name = token:match('^no%-(.+)$') or token
+      if not feature_names:includes(name) then
+        error(("sfs-2487-2024: tuntematon ominaisuus (unknown feature) " ..
+               "'%s' — tuetut (supported): agenda, toc, endmatter-newpage; " ..
+               "no-etuliite poistaa käytöstä (a no- prefix disables one)\n")
+              :format(token))
+      end
+      features[name] = (name == token)
+    end
+  end
+  if features['endmatter-newpage'] == nil then
+    features['endmatter-newpage'] = meta.attachments ~= nil
+      or meta.distribution ~= nil or meta.forinformation ~= nil
+  end
+  for _, name in ipairs(feature_names) do
+    meta['sfs-' .. name] = pandoc.MetaBool(features[name] or false)
+  end
+end
+
 function Meta(meta)
   for _, field in ipairs({'doctype', 'title'}) do
     if meta[field] == nil then
@@ -118,15 +164,7 @@ function Meta(meta)
       end
     end
   end
-  -- The pöytäkirja model document starts its end matter on a fresh page;
-  -- contact info alone stays inline (tarjous model document). Frontmatter
-  -- endmatter-newpage overrides either way; the class itself separates the
-  -- inline end matter from the body by a paragraph gap.
-  if meta['endmatter-newpage'] == nil then
-    meta['endmatter-newpage'] = pandoc.MetaBool(
-      meta.attachments ~= nil or meta.distribution ~= nil
-      or meta.forinformation ~= nil)
-  end
+  parse_features(meta)
   return meta
 end
 


### PR DESCRIPTION
Replace the top-level agenda/toc/endmatter-newpage booleans with a
single features list, e.g. features: [agenda, no-endmatter-newpage].
A no- prefix turns a feature off, which keeps the computed
endmatter-newpage default (on whenever attachments, distribution or
forinformation are present) overridable in both directions.

Pandoc templates cannot test list membership, so the Lua filter
expands the tokens into sfs-* booleans the template reads; the rename
also keeps the removed legacy keys inert, and the filter fails the
build with a migration hint when it sees one. Unknown feature names
are an error, and a bare scalar (features: agenda) is accepted.

https://claude.ai/code/session_01XN84GbSG1U5qGtLMUGZcY6