### PR TITLE
docs: link example source files alongside rendered PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ devenv.local.yaml
 *.toc
 result
 docs/pdf/
+docs/src/
 site/
 build/
 *.curlopt

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,21 @@ markdown: $(LOGOS)  ## Build every examples/markdown/esimerkki-*.md with the nix
 
 .PHONY: docs
 docs: examples markdown  ## Build the documentation site into site/
-	@rm -rf docs/pdf
+	@rm -rf docs/pdf docs/src
 	@mkdir -p docs/pdf/latex docs/pdf/markdown
 	@cp examples/latex/esimerkki-*.pdf docs/pdf/latex/
 	@cp examples/markdown/esimerkki-*.pdf docs/pdf/markdown/
+	@# Copy the example sources next to the PDFs so the docs site can link
+	@# to them. The .txt suffix makes every host (GitHub Pages included)
+	@# serve them as text/plain, so browsers render them inline instead of
+	@# downloading.
+	@mkdir -p docs/src/latex docs/src/markdown
+	@for f in examples/latex/esimerkki-*.tex; do \
+		cp "$$f" "docs/src/latex/$$(basename $$f).txt"; \
+	done
+	@for f in examples/markdown/esimerkki-*.md; do \
+		cp "$$f" "docs/src/markdown/$$(basename $$f).txt"; \
+	done
 	@nix shell .#docsEnv --command mkdocs build --strict
 
 .PHONY: watch
@@ -44,7 +55,7 @@ watch:  ## Develop PDF and watch for changes
 clean:
 	@latexmk -cd -C -quiet examples/latex/esimerkki-*.tex examples/logo-*.tex
 	@rm -f examples/latex/*.fls examples/markdown/esimerkki-*.pdf
-	@rm -rf docs/pdf site
+	@rm -rf docs/pdf docs/src site
 
 .PHONY: shell
 shell:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,14 +5,18 @@ a LaTeX original in `examples/latex/` and a Markdown twin in
 `examples/markdown/` that produces the same layout. The rendered PDFs
 below are built from this very revision of the class.
 
-| Example | Demonstrates | LaTeX PDF | Markdown PDF |
+Each row links to the rendered PDF and to the source it was built from.
+The source links open in the browser as plain text, so you can read them
+without downloading first.
+
+| Example | Demonstrates | LaTeX | Markdown |
 |---|---|---|---|
-| `esimerkki-poytakirja` | The standard's own Liite A example: two-page minutes with margin labels, electronic signatures, attachment lists, distribution and contact info | [PDF](pdf/latex/esimerkki-poytakirja.pdf) | [PDF](pdf/markdown/esimerkki-poytakirja.pdf) |
-| `esimerkki-tarjous` | The standard's own Liite B example: quotation with document id, extra metadata, recipient area, closing greeting (6.5.4) and handwritten signature (6.6.1) | [PDF](pdf/latex/esimerkki-tarjous.pdf) | [PDF](pdf/markdown/esimerkki-tarjous.pdf) |
-| `esimerkki-kokouskutsu` | Meeting invitation with an agenda, using the `agenda` option's `1.` numbering and an unnumbered *Esityslista* heading | [PDF](pdf/latex/esimerkki-kokouskutsu.pdf) | [PDF](pdf/markdown/esimerkki-kokouskutsu.pdf) |
-| `esimerkki-raportti` | Multi-page report: table of contents (6.10), table with its caption above and a bold header row (6.5.1), footnote (6.9), three heading levels | [PDF](pdf/latex/esimerkki-raportti.pdf) | [PDF](pdf/markdown/esimerkki-raportti.pdf) |
-| `esimerkki-kayttoohje` | `sans-serif` manual with captioned figures in the text flow (6.5.2) and numbered step lists | [PDF](pdf/latex/esimerkki-kayttoohje.pdf) | [PDF](pdf/markdown/esimerkki-kayttoohje.pdf) |
-| `esimerkki-monospace` | `monospace` memo demonstrating the Courier typewriter font | [PDF](pdf/latex/esimerkki-monospace.pdf) | [PDF](pdf/markdown/esimerkki-monospace.pdf) |
+| `esimerkki-poytakirja` | The standard's own Liite A example: two-page minutes with margin labels, electronic signatures, attachment lists, distribution and contact info | [PDF](pdf/latex/esimerkki-poytakirja.pdf) · [source](src/latex/esimerkki-poytakirja.tex.txt) | [PDF](pdf/markdown/esimerkki-poytakirja.pdf) · [source](src/markdown/esimerkki-poytakirja.md.txt) |
+| `esimerkki-tarjous` | The standard's own Liite B example: quotation with document id, extra metadata, recipient area, closing greeting (6.5.4) and handwritten signature (6.6.1) | [PDF](pdf/latex/esimerkki-tarjous.pdf) · [source](src/latex/esimerkki-tarjous.tex.txt) | [PDF](pdf/markdown/esimerkki-tarjous.pdf) · [source](src/markdown/esimerkki-tarjous.md.txt) |
+| `esimerkki-kokouskutsu` | Meeting invitation with an agenda, using the `agenda` option's `1.` numbering and an unnumbered *Esityslista* heading | [PDF](pdf/latex/esimerkki-kokouskutsu.pdf) · [source](src/latex/esimerkki-kokouskutsu.tex.txt) | [PDF](pdf/markdown/esimerkki-kokouskutsu.pdf) · [source](src/markdown/esimerkki-kokouskutsu.md.txt) |
+| `esimerkki-raportti` | Multi-page report: table of contents (6.10), table with its caption above and a bold header row (6.5.1), footnote (6.9), three heading levels | [PDF](pdf/latex/esimerkki-raportti.pdf) · [source](src/latex/esimerkki-raportti.tex.txt) | [PDF](pdf/markdown/esimerkki-raportti.pdf) · [source](src/markdown/esimerkki-raportti.md.txt) |
+| `esimerkki-kayttoohje` | `sans-serif` manual with captioned figures in the text flow (6.5.2) and numbered step lists | [PDF](pdf/latex/esimerkki-kayttoohje.pdf) · [source](src/latex/esimerkki-kayttoohje.tex.txt) | [PDF](pdf/markdown/esimerkki-kayttoohje.pdf) · [source](src/markdown/esimerkki-kayttoohje.md.txt) |
+| `esimerkki-monospace` | `monospace` memo demonstrating the Courier typewriter font | [PDF](pdf/latex/esimerkki-monospace.pdf) · [source](src/latex/esimerkki-monospace.tex.txt) | [PDF](pdf/markdown/esimerkki-monospace.pdf) · [source](src/markdown/esimerkki-monospace.md.txt) |
 
 `esimerkki-poytakirja` and `esimerkki-tarjous` replicate the standard's
 own model documents (Liite A and B in SFS 2487:2024), so their output


### PR DESCRIPTION
## Summary

The examples page in the docs only linked the rendered PDFs. This adds a **source** link for each LaTeX and Markdown example so readers can see how each document is written, right next to its PDF.

To make sure the browser renders the source inline instead of forcing a download, the docs build copies each example source into `docs/src/` with a `.txt` suffix. The suffix makes every host — GitHub Pages included — serve the files as `text/plain`, so they open directly in the browser.

## Changes

- **`Makefile`** — the `docs` target now copies `examples/latex/esimerkki-*.tex` and `examples/markdown/esimerkki-*.md` into `docs/src/{latex,markdown}/` with a `.txt` suffix; `clean` removes `docs/src/`.
- **`docs/examples.md`** — each table cell now links both the `PDF` and the `source`, with a short note explaining the source links open as plain text.
- **`.gitignore`** — ignore `docs/src/` (a build artifact, like `docs/pdf/`).

## Verification

- `mkdocs build --strict` passes — all new `src/...` links resolve and the sources are copied into `site/src/`.

https://claude.ai/code/session_01R3b5mnoC9a2gseUYBLutgH

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3b5mnoC9a2gseUYBLutgH)_