### PR TITLE
Wrap long words in monospace documents

### DIFF
--- a/sfs-2487-2024.cls
+++ b/sfs-2487-2024.cls
@@ -60,6 +60,12 @@
 \else\ifsfs@font@mono
   \RequirePackage{courier}
   \renewcommand{\familydefault}{\ttdefault}
+  % Courier's font definition (t1pcr.fd) disables hyphenation with
+  % \hyphenchar\font\m@ne, so long Finnish compound words cannot break and
+  % overflow the right margin under the global \RaggedRight. Re-enable it so
+  % the body wraps like the serif/sans-serif fonts; the spec suppresses
+  % hyphenation only in headings (6.4), which \sfs@nohyphens still handles.
+  \DeclareFontFamily{T1}{pcr}{\hyphenchar\font=`\-}
 \else
   \RequirePackage{helvet}
   \renewcommand{\familydefault}{\sfdefault}


### PR DESCRIPTION
## Problem

In `[monospace]` documents, long lines did not wrap — they overflowed past the document's right border. `esimerkki-monospace` produced four overfull `\hbox` warnings (up to 52.6 pt too wide), with long Finnish compound words such as *identiteetinhallintajärjestelmä* and *hallintarajapinnassa* running into the right margin.

## Root cause

Courier's font definition file (`t1pcr.fd`) hard-codes `\hyphenchar\font\m@ne` in its family-loading code, setting the hyphen character to `-1` for every Courier font loaded. That disables hyphenation entirely. Under the class's global `\RaggedRight`, a word with no break opportunity simply overflows the line — whereas the serif and sans-serif fonts hyphenate such words and stay within the margin.

## Fix

Re-declare the `pcr` family in the `[monospace]` branch so its loading code sets `\hyphenchar` back to the hyphen, re-enabling hyphenation:

```latex
\DeclareFontFamily{T1}{pcr}{\hyphenchar\font=`\-}
```

Body text now wraps like the other fonts. Heading hyphenation stays suppressed via the existing `\sfs@nohyphens` (spec clause 6.4), so this only affects body wrapping.

## Verification

- `esimerkki-monospace` (LaTeX) and its Markdown twin both build with **0 overfull boxes** (was 4).
- Text right edge now sits at the right margin (~567.8 pt vs page 595.3 pt − 10 mm), down from a 52 pt overflow.
- Change is scoped strictly to the `\ifsfs@font@mono` branch; serif/sans-serif examples are untouched.

https://claude.ai/code/session_01JGeLaEWvyDTb3xEwo8pX7c

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGeLaEWvyDTb3xEwo8pX7c)_