### PR TITLE
Deploy the web editor to GitHub Pages under /web/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,11 @@ docs: examples markdown  ## Build the documentation site into site/
 		cp "$$f" "docs/src/markdown/$$(basename $$f).txt"; \
 	done
 	@nix shell .#docsEnv --command mkdocs build --strict
+	@# Place the browser editor under site/web/ so Pages serves it at
+	@# <site>/web/ (e.g. datakurre.github.io/vakioasiakirja/web/). Done after
+	@# mkdocs, which cleans site/; the bundle's relative base works at any path.
+	@nix build .#web
+	@mkdir -p site/web && cp -rL result/. site/web/ && chmod -R u+w site/web
 
 .PHONY: watch
 watch:  ## Develop PDF and watch for changes

--- a/docs/web-editor.md
+++ b/docs/web-editor.md
@@ -6,6 +6,14 @@ local TeX installation. It is a design study, not a shipped feature:
 the goal is to compare the realistic options and decide between them
 with two small prototypes before committing to an implementation.
 
+!!! tip "Try it"
+
+    The first prototype is live at
+    [**datakurre.github.io/vakioasiakirja/web/**](https://datakurre.github.io/vakioasiakirja/web/)
+    — write Markdown on the left, get the SFS 2487 PDF on the right,
+    entirely in your browser. Its source is in
+    [`web/`](https://github.com/datakurre/vakioasiakirja/tree/main/web).
+
 The existing converter (`nix run .`) already turns Markdown into a
 conforming PDF, but it needs nix or a TeX Live installation on the
 machine. A browser editor would let someone write a document and get
@@ -205,7 +213,12 @@ left for the day byte-identical output becomes a requirement.
 
 The prototype builds reproducibly through the flake — `nix build .#web`
 (or `make web`) produces the static bundle, pinning the WebAssembly
-artifacts and fonts; `make web-dev` runs it live. Publishing it to
-GitHub Pages under `/web/` alongside this documentation site, by
-extending `.github/workflows/docs.yml`, is the next step once the
-prototype graduates from a spike.
+artifacts and fonts; `make web-dev` runs it live. The bundle uses a
+relative base, so it works at any path.
+
+`make docs` builds it and copies it into `site/web/` after the mkdocs
+site, so the same GitHub Pages deployment that publishes these docs also
+serves the editor at
+[datakurre.github.io/vakioasiakirja/web/](https://datakurre.github.io/vakioasiakirja/web/).
+The existing `.github/workflows/docs.yml` runs `make docs`, so no
+workflow change is needed; the PR `smoke-test` workflow builds it too.

--- a/flake.nix
+++ b/flake.nix
@@ -29,13 +29,15 @@
         ]);
 
         # Browser editor prototype (web/): a typst.ts Markdown→PDF spike,
-        # built into a static bundle. VITE_BASE sets the deployment subpath;
-        # default "/web/" matches the GitHub Pages layout next to the docs.
+        # built into a static bundle. A relative base ("./") lets it be
+        # served from any path — in particular GitHub Pages' project subpath
+        # (datakurre.github.io/vakioasiakirja/web/), where `make docs` places
+        # it under site/web/.
         web = pkgs.buildNpmPackage {
           name = "sfs-2487-2024-web-editor";
           src = ./web;
           npmDepsHash = "sha256-haZ3VxJlqi1DJyu2zA+1zBIXxr008fJlO8JBp9PLGns=";
-          VITE_BASE = "/web/";
+          VITE_BASE = "./";
           installPhase = ''
             runHook preInstall
             cp -r dist $out

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: sfs-2487-2024
+site_url: https://datakurre.github.io/vakioasiakirja/
 site_description: >-
   LaTeX document class and Markdown-to-PDF converter for Finnish office
   documents following SFS 2487:2024
@@ -27,3 +28,4 @@ nav:
   - Examples: examples.md
   - Development: development.md
   - Web editor (research): web-editor.md
+  - Open the editor: https://datakurre.github.io/vakioasiakirja/web/


### PR DESCRIPTION
Serve the browser editor from the same Pages site as the docs, at datakurre.github.io/vakioasiakirja/web/. The flake builds the bundle with a relative base ("./") so it works at any path, and `make docs` copies it into site/web/ after mkdocs (which cleans site/). The existing docs.yml workflow runs `make docs`, so it now publishes the editor too; the PR smoke-test workflow builds it as well. Add a site_url, a nav entry and an in-page link to the live editor.

Verified end to end: `make docs` builds the full site including site/web/, and the artifact compiles in a headless browser when served under /vakioasiakirja/web/ (relative base resolves the WASM and fonts).

https://claude.ai/code/session_01SCYxbzNAqLBt9fp2kLECkY