### PR TITLE
Fix Courier font shape declaration in T1 encoding

### DIFF
--- a/sfs-2487-2024.cls
+++ b/sfs-2487-2024.cls
@@ -65,6 +65,11 @@
   % overflow the right margin under the global \RaggedRight. Re-enable it so
   % the body wraps like the serif/sans-serif fonts; the spec suppresses
   % hyphenation only in headings (6.4), which \sfs@nohyphens still handles.
+  % Read t1pcr.fd first so Courier's shapes are declared, then redeclare the
+  % family with the hyphenation hook: declaring the family before the .fd is
+  % read marks T1/pcr as known and suppresses NFSS's automatic load, leaving
+  % every Courier shape undefined and defaulting the body to Computer Modern.
+  \InputIfFileExists{t1pcr.fd}{}{}
   \DeclareFontFamily{T1}{pcr}{\hyphenchar\font=`\-}
 \else
   \RequirePackage{helvet}


### PR DESCRIPTION
## Summary

Fixes a font declaration order issue that caused Courier shapes to be undefined in T1 encoding, causing the body text to incorrectly default to Computer Modern.

## Changes

- **Load `t1pcr.fd` before redeclaring the T1/pcr font family**: The NFSS font selection scheme requires that font definition files (`.fd`) be loaded before a family is declared. Previously, declaring `T1/pcr` before loading `t1pcr.fd` marked the family as "known" to NFSS, which suppressed the automatic load of the `.fd` file. This left all Courier shapes undefined and caused the body text to fall back to Computer Modern.

- **Preserve hyphenation hook**: The redeclaration of `T1/pcr` with `\hyphenchar\font=`\-`` is retained to apply the hyphenation settings required by the standard (section 6.4).

## Implementation Details

The fix adds `\InputIfFileExists{t1pcr.fd}{}{}` immediately before the existing `\DeclareFontFamily{T1}{pcr}{\hyphenchar\font=`\-}` line. This ensures:
1. Courier's font shapes are declared by the `.fd` file
2. The family is then redeclared with the hyphenation hook applied
3. Body text correctly uses Courier instead of defaulting to Computer Modern

This resolves the font selection issue without affecting the hyphenation behavior specified in the standard.

https://claude.ai/code/session_01SLPkY6dLBJdNH82WAgWJnF