### PR TITLE
Add logo upload support to web editor

### DIFF
--- a/docs/web-editor.md
+++ b/docs/web-editor.md
@@ -202,9 +202,14 @@ not to, which would break offline use; the editor disables that and ships
 only the bundled TeX Gyre faces.
 
 So the open question — can a Typst template reproduce the layout and
-compile from Markdown client-side — is answered **yes**. What the spike
-does *not* cover: tagged-PDF accessibility and image/logo uploads. The
-Markdown editor is a third rendering path and, for now, a best-effort
+compile from Markdown client-side — is answered **yes**. Logo upload is
+now supported too: since the browser cannot read the `logo:` frontmatter
+path, the editor's **Logo** control uploads a PNG/JPEG/SVG image, which
+is registered in typst.ts's shadow filesystem with `$typst.mapShadow`
+and rendered in the 20 mm margin (capped at 20 mm height); SVG logos
+need no `rsvg-convert` because Typst decodes SVG natively. What the spike
+still does *not* cover: tagged-PDF accessibility and PDF-format logos.
+The Markdown editor is a third rendering path and, for now, a best-effort
 one; the LaTeX class stays the reference implementation. Spike 2 (the
 WebAssembly-LaTeX route) was not needed to answer the question and is
 left for the day byte-identical output becomes a requirement.

--- a/web/README.md
+++ b/web/README.md
@@ -89,13 +89,26 @@ self-contained use. `web/src/main.ts` passes `preloadRemoteFonts(FONTS,
 { assets: false })` so only the bundled TeX Gyre faces are used and nothing is
 fetched from the network.
 
+## Logo upload
+
+The committed Markdown examples carry a `logo:` frontmatter key pointing at a
+file (`logo: ../logo-organisaatio.pdf`), but the browser has no filesystem
+access, so that path is ignored here. Instead the editor's **Logo** control
+uploads an image (PNG, JPEG or SVG): `src/main.ts` reads the file into a
+`Uint8Array` and registers it in typst.ts's shadow virtual filesystem with
+`$typst.mapShadow("/logo.<ext>", bytes)`, and the converter emits
+`logo: image("/logo.<ext>")` into the `sfs-document(...)` call. The template
+hangs it in the 20 mm margin and caps it at 20 mm height (scaling down only when
+taller, like the LaTeX class). **Poista logo** removes it again. SVG logos work
+natively — Typst decodes SVG itself, so the pandoc pipeline's `rsvg-convert`
+step is not needed.
+
 ## Known gaps (out of scope for the spike)
 
 - Tagged-PDF accessibility (the class's `\DocumentMetadata{tagging=on}`) is not
   reproduced; Typst supports PDF/A and tagging, to revisit.
-- Logo/image assets: the converter drops a `logo:` that points at an external
-  file (the browser has no filesystem access to it); a real upload/VFS path is
-  future work.
+- PDF logos (as the committed examples use) cannot be uploaded — only the
+  browser-native raster/SVG formats are accepted.
 - Footnotes, tables and the TOC feature are wired through but exercised less
   than in the LaTeX examples.
 - Fonts are bundled in-repo for a self-contained prototype; a production build

--- a/web/index.html
+++ b/web/index.html
@@ -8,6 +8,10 @@
   <body>
     <header>
       <strong>SFS 2487:2024</strong> – Markdown → PDF (typst.ts-prototyyppi)
+      <label id="logo-label">Logo
+        <input id="logo" type="file" accept="image/png,image/jpeg,image/svg+xml" />
+      </label>
+      <button id="logo-clear" hidden>Poista logo</button>
       <button id="download" disabled>Lataa PDF</button>
       <span id="status">ladataan…</span>
     </header>

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -42,6 +42,8 @@ $typst.setRendererInitOptions({ getModule: () => rendererWasmUrl });
 const statusEl = document.getElementById("status")!;
 const downloadEl = document.getElementById("download") as HTMLButtonElement;
 const previewEl = document.getElementById("preview")!;
+const logoEl = document.getElementById("logo") as HTMLInputElement;
+const logoClearEl = document.getElementById("logo-clear") as HTMLButtonElement;
 
 function setStatus(text: string, error = false) {
   statusEl.textContent = text;
@@ -51,16 +53,31 @@ function setStatus(text: string, error = false) {
 let templateAdded = false;
 let currentTypst = "";
 
+// An uploaded logo image, mapped into the typst.ts shadow filesystem. The
+// frontmatter `logo:` key is a filesystem path the browser cannot read, so the
+// logo is driven by the upload control instead (see withoutLogo).
+let logo: { path: string; bytes: Uint8Array } | undefined;
+
 // The strip-the-logo guard: the seeded example references an external logo
-// file that the browser has no access to; drop it so the prototype renders.
+// file that the browser has no access to; drop the frontmatter line so it never
+// reaches the converter. Uploaded logos take the VFS path below instead.
 function withoutLogo(md: string): string {
   return md.replace(/^logo:.*$/m, "");
+}
+
+// Pick a shadow-filesystem path whose extension matches the upload, so Typst's
+// image() decodes it by format. Only the browser-native raster/SVG formats are
+// offered (PDF logos, used by the committed examples, are out of scope here).
+function logoPathFor(file: File): string {
+  if (file.type === "image/svg+xml" || /\.svg$/i.test(file.name)) return "/logo.svg";
+  if (file.type === "image/jpeg" || /\.jpe?g$/i.test(file.name)) return "/logo.jpg";
+  return "/logo.png";
 }
 
 async function render(md: string) {
   let typst: string;
   try {
-    typst = markdownToTypst(md);
+    typst = markdownToTypst(md, { logoPath: logo?.path });
   } catch (e) {
     setStatus(e instanceof ConversionError ? e.message : String(e), true);
     return;
@@ -71,6 +88,9 @@ async function render(md: string) {
       await $typst.addSource("/sfs-2487-2024.typ", templateSource);
       templateAdded = true;
     }
+    // Re-map the logo each render: cheap, and keeps the VFS in sync after a
+    // change or removal.
+    if (logo) await $typst.mapShadow(logo.path, logo.bytes);
     const svg = await $typst.svg({ mainContent: typst });
     previewEl.innerHTML = svg;
     downloadEl.disabled = false;
@@ -94,6 +114,26 @@ downloadEl.addEventListener("click", async () => {
   } catch (e) {
     setStatus(String(e), true);
   }
+});
+
+logoEl.addEventListener("change", async () => {
+  const file = logoEl.files?.[0];
+  if (!file) return;
+  const path = logoPathFor(file);
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  // Drop a previous logo at a different path so it does not linger in the VFS.
+  if (logo && logo.path !== path) await $typst.unmapShadow(logo.path);
+  logo = { path, bytes };
+  logoClearEl.hidden = false;
+  render(editor.state.doc.toString());
+});
+
+logoClearEl.addEventListener("click", async () => {
+  if (logo) await $typst.unmapShadow(logo.path);
+  logo = undefined;
+  logoEl.value = "";
+  logoClearEl.hidden = true;
+  render(editor.state.doc.toString());
 });
 
 let timer: number | undefined;

--- a/web/src/md-to-typst.ts
+++ b/web/src/md-to-typst.ts
@@ -33,7 +33,15 @@ function content(typst: string): string {
   return "[" + typst + "]";
 }
 
-function frontmatterToArgs(meta: Record<string, unknown>): string {
+// Options that come from the editor shell rather than the document source.
+export interface ConvertOptions {
+  // VFS path of an uploaded logo image (mapped into typst.ts via mapShadow).
+  // The frontmatter `logo:` key is a filesystem path the browser cannot read,
+  // so the logo is driven by the upload control instead.
+  logoPath?: string;
+}
+
+function frontmatterToArgs(meta: Record<string, unknown>, opts: ConvertOptions): string {
   for (const field of ["doctype", "title"]) {
     if (meta[field] == null) {
       throw new ConversionError(
@@ -48,6 +56,9 @@ function frontmatterToArgs(meta: Record<string, unknown>): string {
   for (const k of ["doctype", "title", "date", "author", "subject", "docid", "confidentiality"]) {
     scalar(k);
   }
+  // The logo is an uploaded image in the shadow filesystem, not a frontmatter
+  // path (the browser cannot read the path the `logo:` key would hold).
+  if (opts.logoPath != null) args.push(`logo: image(${str(opts.logoPath)})`);
   // Multi-line fields: join YAML list (or scalar) with Typst line breaks.
   for (const k of LIST_FIELDS) {
     const v = meta[k];
@@ -349,9 +360,9 @@ function body(markdown: string): string {
   return blocks(tokens, { i: 0 });
 }
 
-export function markdownToTypst(source: string): string {
+export function markdownToTypst(source: string, opts: ConvertOptions = {}): string {
   const meta = parseFrontmatter(source);
-  const args = frontmatterToArgs(meta.frontmatter);
+  const args = frontmatterToArgs(meta.frontmatter, opts);
   const segs = segmentDivs(meta.body);
   let out = "";
   for (const seg of segs) {

--- a/web/src/sfs-2487-2024.typ
+++ b/web/src/sfs-2487-2024.typ
@@ -97,7 +97,15 @@
   // page number is "current (total)" — e.g. 1 (2).
   let metadata-block = {
     if logo != none {
-      place(top + left, dx: -column, box(height: logo-max-height, logo))
+      // Hang the logo in the 20 mm margin, capped at logo-max-height: scale
+      // down only when taller than the cap, never up (cls \logomaxheight).
+      place(top + left, dx: -column, context {
+        if measure(logo).height > logo-max-height {
+          box(height: logo-max-height, logo)
+        } else {
+          logo
+        }
+      })
     }
     place(
       top + left,

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -24,8 +24,22 @@ header {
   flex: 0 0 auto;
 }
 
-header button {
+/* Push the download button (and the status after it) to the right edge; the
+   logo controls stay next to the title on the left. */
+#download {
   margin-left: auto;
+}
+
+#logo-label {
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+#logo-label input {
+  font-size: 0.8rem;
+  max-width: 20ch;
 }
 
 #status {


### PR DESCRIPTION
## Summary

Implements logo image upload functionality in the web editor, allowing users to upload PNG, JPEG, or SVG logos that are rendered in the 20 mm margin of the document. Since the browser cannot access filesystem paths referenced in the `logo:` frontmatter key, the uploaded image is registered in typst.ts's shadow virtual filesystem and passed to the converter via a new `ConvertOptions` parameter.

## Key Changes

- **HTML UI**: Added file input (`#logo`) accepting PNG/JPEG/SVG and a "Poista logo" (Remove logo) button in the header
- **Logo state management** (`main.ts`): 
  - Track uploaded logo as `{ path: string; bytes: Uint8Array }` in memory
  - Implement `logoPathFor()` to select shadow filesystem path (`.svg`, `.jpg`, or `.png`) based on file type
  - Map/unmap logos in the VFS on upload and removal via `$typst.mapShadow()` and `$typst.unmapShadow()`
  - Re-map logo on each render to keep VFS in sync
- **Converter integration** (`md-to-typst.ts`):
  - Add `ConvertOptions` interface with optional `logoPath` parameter
  - Pass logo path to `frontmatterToArgs()` which emits `logo: image("/logo.<ext>")` instead of reading the inaccessible frontmatter path
- **Template improvements** (`sfs-2487-2024.typ`):
  - Scale logo down only when taller than 20 mm cap (never up), matching LaTeX class behavior
  - Use `context` and `measure()` to conditionally apply height constraint
- **Documentation**: Updated README and web-editor.md to explain logo upload workflow and note that PDF logos remain out of scope
- **Styling**: Adjusted header layout to keep logo controls left-aligned while download button stays right-aligned

## Implementation Details

- SVG logos work natively — Typst decodes SVG itself, so no `rsvg-convert` step is needed (unlike the LaTeX pipeline)
- Only browser-native raster/SVG formats are accepted; PDF logos (used by committed examples) cannot be uploaded
- Logo is dropped from frontmatter via `withoutLogo()` to prevent the inaccessible filesystem path from reaching the converter
- VFS cleanup: if user uploads a logo at a different path, the previous path is unmapped to prevent stale entries

https://claude.ai/code/session_018TYUepFkK9mdn6DjgH89Ty