### PR TITLE
Add footnotes, tables, and figure support to Markdown converter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
         web = pkgs.buildNpmPackage {
           name = "sfs-2487-2024-web-editor";
           src = ./web;
-          npmDepsHash = "sha256-haZ3VxJlqi1DJyu2zA+1zBIXxr008fJlO8JBp9PLGns=";
+          npmDepsHash = "sha256-CcDXIfc//wmi2kFhoCVGAfCni1Q7xYyN0vbASxSJxys=";
           VITE_BASE = "./";
           installPhase = ''
             runHook preInstall

--- a/web/README.md
+++ b/web/README.md
@@ -15,7 +15,9 @@ Markdown (YAML front matter + body)
   └─ src/md-to-typst.ts   port of pandoc/sfs-2487-2024.lua + the template:
   │                       front matter → sfs-document arguments, definition
   │                       lists → #marginlabel, ::: esignatures/handsignature/
-  │                       marginlabel divs, ≤3 heading levels, Finnish quotes
+  │                       marginlabel divs, ≤3 heading levels (unnumbered with
+  │                       {-}), footnotes, pipe tables + captions, captioned
+  │                       image figures, Finnish quotes
   ▼
 Typst (#import "/sfs-2487-2024.typ")
   └─ src/sfs-2487-2024.typ   the layout, reimplemented from sfs-2487-2024.cls:
@@ -25,7 +27,8 @@ Typst (#import "/sfs-2487-2024.typ")
   │                          column (the no-runin feature opts out)
   ▼
 typst.ts (WASM, in the browser)
-  ├─ $typst.svg(...)   live preview
+  ├─ $typst.svg(...)   live preview (split into one cropped sheet per page so
+  │                    each scales to fit, instead of one fused tall SVG)
   └─ $typst.pdf(...)   downloadable PDF
 ```
 
@@ -109,8 +112,11 @@ step is not needed.
   reproduced; Typst supports PDF/A and tagging, to revisit.
 - PDF logos (as the committed examples use) cannot be uploaded — only the
   browser-native raster/SVG formats are accepted.
-- Footnotes, tables and the TOC feature are wired through but exercised less
-  than in the LaTeX examples.
+- PDF metadata is set from the front matter (title, author, keywords, the
+  `lang fi`, and the document date as the creation/modification date), but
+  Typst's `set document` has no *subject* field, so `subject` and a separate
+  `modified` date are not written to the PDF properties (they are in the LaTeX
+  output) — best-effort.
 - Fonts are bundled in-repo for a self-contained prototype; a production build
   would pin them through nix instead.
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,7 +17,8 @@
         "codemirror": "^6.0.1",
         "js-yaml": "^4.1.0",
         "markdown-it": "^14.1.0",
-        "markdown-it-deflist": "^3.0.0"
+        "markdown-it-deflist": "^3.0.0",
+        "markdown-it-footnote": "^4.0.0"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -1307,6 +1308,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-3.0.1.tgz",
       "integrity": "sha512-pPtXxihDMi9jrwLLQ+Jra/FM20F/FFJWiVjXf0Js6Lwp7LFj+MuK6cUJNMVTRL+n9d/JqF4MEqYZwSMgVodK5g==",
+      "license": "MIT"
+    },
+    "node_modules/markdown-it-footnote": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
+      "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
       "license": "MIT"
     },
     "node_modules/mdurl": {

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,8 @@
     "codemirror": "^6.0.1",
     "js-yaml": "^4.1.0",
     "markdown-it": "^14.1.0",
-    "markdown-it-deflist": "^3.0.0"
+    "markdown-it-deflist": "^3.0.0",
+    "markdown-it-footnote": "^4.0.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -50,6 +50,52 @@ function setStatus(text: string, error = false) {
   statusEl.classList.toggle("error", error);
 }
 
+// typst.ts returns a single SVG with all pages stacked seamlessly in one
+// coordinate space (transparent page backgrounds). Rendered as one element it
+// reads as a single tall sheet with the page margins fused into a big blank
+// band — the "extra padding". Split it into one cropped <svg> per page so each
+// shows as a separate, correctly proportioned sheet that scales to fit.
+function showPages(svgText: string) {
+  // The browser's lenient HTML parser handles typst.ts's inline <style> block
+  // (strict XML DOMParser chokes on it); a detached div gives us the live SVG.
+  const holder = document.createElement("div");
+  holder.innerHTML = svgText;
+  const base = holder.querySelector("svg");
+  if (!base) {
+    previewEl.innerHTML = svgText;
+    return;
+  }
+  // typst.ts embeds a <script> for interactivity; cloned once per page it would
+  // re-declare its globals (a console error). The static preview does not need
+  // it, so drop it before cloning.
+  base.querySelectorAll("script").forEach((s) => s.remove());
+  const pages = Array.from(base.querySelectorAll("g.typst-page"));
+  if (pages.length === 0) {
+    previewEl.replaceChildren(base);
+    return;
+  }
+  const cards: SVGSVGElement[] = [];
+  for (const page of pages) {
+    const t = (page.getAttribute("transform") ?? "").match(/translate\(\s*([-\d.]+)[,\s]+([-\d.]+)/);
+    const y = t ? parseFloat(t[2]) : 0;
+    const w = parseFloat(page.getAttribute("data-page-width") ?? "0");
+    const h = parseFloat(page.getAttribute("data-page-height") ?? "0");
+    const card = base.cloneNode(true) as SVGSVGElement;
+    // Crop to this page's slice; clip to it (typst sets overflow:visible, which
+    // would otherwise leak the other pages into the view).
+    card.setAttribute("viewBox", `0 ${y} ${w} ${h}`);
+    card.setAttribute("width", String(w));
+    card.setAttribute("height", String(h));
+    card.setAttribute("preserveAspectRatio", "xMidYMid meet");
+    card.style.overflow = "hidden";
+    card.removeAttribute("data-width");
+    card.removeAttribute("data-height");
+    card.classList.add("page");
+    cards.push(card);
+  }
+  previewEl.replaceChildren(...cards);
+}
+
 let templateAdded = false;
 let currentTypst = "";
 
@@ -92,7 +138,7 @@ async function render(md: string) {
     // change or removal.
     if (logo) await $typst.mapShadow(logo.path, logo.bytes);
     const svg = await $typst.svg({ mainContent: typst });
-    previewEl.innerHTML = svg;
+    showPages(svg);
     downloadEl.disabled = false;
     setStatus("käännetty");
   } catch (e) {

--- a/web/src/md-to-typst.ts
+++ b/web/src/md-to-typst.ts
@@ -5,12 +5,22 @@
 
 import MarkdownIt from "markdown-it";
 import deflist from "markdown-it-deflist";
+import footnote from "markdown-it-footnote";
 import yaml from "js-yaml";
 import type Token from "markdown-it/lib/token.mjs";
 
-const md = new MarkdownIt({ html: false, linkify: false, typographer: false }).use(
-  deflist,
-);
+const md = new MarkdownIt({ html: false, linkify: false, typographer: false })
+  .use(deflist)
+  .use(footnote);
+
+// The footnote plugin stores each note's content in the parse env, keyed by id;
+// the active env is set in body() so inlines() can resolve a footnote_ref to its
+// content at the reference site (cls/pandoc render footnotes as real \footnote).
+let footnoteEnv: { footnotes?: { list?: Record<number, { tokens?: Token[] }> } } = {};
+
+// A table caption written pandoc-style on its own line (": Otsikko" or
+// "Table: Otsikko") just before a table; consumed by the next table.
+let pendingCaption: string | null = null;
 
 // Front matter keys that carry one or more lines (YAML scalar or list); the
 // template joins list items with line breaks.
@@ -159,11 +169,24 @@ function inlines(tokens: Token[]): string {
         out += `#image(${str(src)})`;
         break;
       }
+      case "footnote_ref": {
+        const id = (t.meta as { id?: number } | undefined)?.id;
+        const note = id != null ? footnoteEnv.footnotes?.list?.[id] : undefined;
+        out += `#footnote[${note ? renderNote(note.tokens ?? []) : ""}]`;
+        break;
+      }
       default:
         if (t.children) out += inlines(t.children);
     }
   }
   return out;
+}
+
+// Render a footnote's stored content: a reference note ([^id]: …) carries block
+// tokens, an inline note (^[…]) a single "inline" token.
+function renderNote(tokens: Token[]): string {
+  const blockLevel = tokens.some((t) => t.type.endsWith("_open") && t.block);
+  return (blockLevel ? blocks(tokens, { i: 0 }) : inlines(tokens)).trim();
 }
 
 interface Cursor {
@@ -183,14 +206,54 @@ function blocks(tokens: Token[], cur: Cursor, stop?: string): string {
             "sfs-2487-2024: SFS 2487:2024 suosittaa enintään kolmea otsikkotasoa (at most three heading levels)",
           );
         }
-        const body = inlines(tokens[cur.i + 1].children ?? []);
-        out += "=".repeat(level) + " " + body + "\n\n";
+        const inline = tokens[cur.i + 1];
+        let body = inlines(inline.children ?? []);
+        // Pandoc heading attributes ({-}, {.unnumbered}, {#id}) suppress the
+        // section number, like \section* in the class; strip the block and
+        // emit an unnumbered heading.
+        const attr = (inline.content ?? "").match(/\s*\{([^}]*)\}\s*$/);
+        const tokensOf = attr ? attr[1].split(/\s+/).filter(Boolean) : [];
+        const isAttrBlock = tokensOf.length > 0 && tokensOf.every((a) => /^[.#-]|=/.test(a));
+        if (isAttrBlock) {
+          body = body.replace(/\s*\{[^}]*\}\s*$/, "");
+          const unnumbered = tokensOf.includes("-") || tokensOf.includes(".unnumbered");
+          out += unnumbered
+            ? `#heading(level: ${level}, numbering: none)[${body}]\n\n`
+            : "=".repeat(level) + " " + body + "\n\n";
+        } else {
+          out += "=".repeat(level) + " " + body + "\n\n";
+        }
         cur.i += 3; // heading_open, inline, heading_close
         continue;
       }
       case "paragraph_open": {
-        out += inlines(tokens[cur.i + 1].children ?? []) + "\n\n";
+        const children = tokens[cur.i + 1].children ?? [];
+        // A paragraph holding only an image becomes a captioned figure
+        // (pandoc implicit_figures, 6.5.2), the alt text its caption.
+        const imgs = children.filter((c) => c.type !== "softbreak");
+        if (imgs.length === 1 && imgs[0].type === "image") {
+          const img = imgs[0];
+          const src = img.attrGet("src") ?? "";
+          const caption = inlines(img.children ?? []) || esc(img.content ?? "");
+          out += `#figure(image(${str(src)}), caption: [${caption}], kind: image)\n\n`;
+          cur.i += 3;
+          continue;
+        }
+        // A pandoc table caption line (": Otsikko" / "Table: Otsikko") is held
+        // back for the table that follows; if none follows it is plain text.
+        const text = inlines(children);
+        const cap = text.match(/^(?:Table:|:)\s+([\s\S]+)$/);
+        if (cap && nextBlockIsTable(tokens, cur.i + 3)) {
+          pendingCaption = cap[1].trim();
+          cur.i += 3;
+          continue;
+        }
+        out += text + "\n\n";
         cur.i += 3;
+        continue;
+      }
+      case "table_open": {
+        out += table(tokens, cur);
         continue;
       }
       case "bullet_list_open":
@@ -229,6 +292,75 @@ function list(tokens: Token[], cur: Cursor, close: string): string {
   cur.i++; // list_close
   const marker = ordered ? "+ " : "- ";
   return items.map((it) => marker + it.replace(/\n/g, "\n  ")).join("\n") + "\n\n";
+}
+
+// True if the next meaningful block token (from index j) opens a table.
+function nextBlockIsTable(tokens: Token[], j: number): boolean {
+  while (j < tokens.length) {
+    const ty = tokens[j].type;
+    if (ty === "table_open") return true;
+    if (ty.endsWith("_open") || ty === "hr" || ty === "fence" || ty === "code_block") return false;
+    j++;
+  }
+  return false;
+}
+
+// Pipe table -> a left-aligned #table with booktabs-style horizontal rules,
+// wrapped in #figure when a caption is pending so it is numbered "Taulukko N"
+// with the caption above (cls captionof[table], 6.5.1). Column alignment comes
+// from the delimiter row (markdown-it sets text-align on the header cells).
+function table(tokens: Token[], cur: Cursor): string {
+  const aligns: string[] = [];
+  const header: string[] = [];
+  const rows: string[][] = [];
+  let inHeader = false;
+  let row: string[] | null = null;
+  cur.i++; // table_open
+  while (cur.i < tokens.length && tokens[cur.i].type !== "table_close") {
+    const t = tokens[cur.i];
+    switch (t.type) {
+      case "thead_open":
+        inHeader = true;
+        break;
+      case "thead_close":
+        inHeader = false;
+        break;
+      case "tr_open":
+        row = [];
+        break;
+      case "tr_close":
+        if (row) {
+          if (inHeader) header.push(...row);
+          else rows.push(row);
+        }
+        row = null;
+        break;
+      case "th_open":
+      case "td_open": {
+        const style = t.attrGet("style") ?? "";
+        if (inHeader) aligns.push(style.includes("right") ? "right" : style.includes("center") ? "center" : "left");
+        const cell = inlines(tokens[cur.i + 1].children ?? []).trim();
+        row?.push(`[${cell}]`);
+        cur.i += 2; // td_open, inline (td_close consumed by loop ++)
+        break;
+      }
+    }
+    cur.i++;
+  }
+  cur.i++; // table_close
+
+  const cols = aligns.length || (rows[0]?.length ?? 1);
+  const alignTuple = `(${aligns.join(", ")})`;
+  let tbl = `table(\n  columns: ${cols},\n  align: ${alignTuple},\n  stroke: none,\n`;
+  tbl += "  table.hline(),\n";
+  if (header.length) tbl += `  table.header(${header.join(", ")}),\n  table.hline(),\n`;
+  for (const r of rows) tbl += "  " + r.join(", ") + ",\n";
+  tbl += "  table.hline(),\n)";
+
+  const caption = pendingCaption;
+  pendingCaption = null;
+  if (caption) return `#figure(\n  ${tbl},\n  caption: [${caption}],\n  kind: table,\n)\n\n`;
+  return "#" + tbl + "\n\n";
 }
 
 // Definition list -> #marginlabel(term)[definition] (cls: term at the 20 mm
@@ -356,8 +488,15 @@ function marginlabelDiv(seg: Segment): string {
 }
 
 function body(markdown: string): string {
-  const tokens = md.parse(markdown, {});
-  return blocks(tokens, { i: 0 });
+  const env = {};
+  const tokens = md.parse(markdown, env);
+  const prev = footnoteEnv;
+  footnoteEnv = env;
+  try {
+    return blocks(tokens, { i: 0 });
+  } finally {
+    footnoteEnv = prev;
+  }
 }
 
 export function markdownToTypst(source: string, opts: ConvertOptions = {}): string {

--- a/web/src/sfs-2487-2024.typ
+++ b/web/src/sfs-2487-2024.typ
@@ -66,6 +66,23 @@
 // (cls \handsignature: three paragraph gaps above the printed line).
 #let handsignature(line) = block(above: 3 * parskip, below: 0pt, line)
 
+// The document date (6.2) is given in the standard's d.m.yyyy form. Parse it
+// into a `datetime` so it becomes the PDF CreationDate/ModDate, matching the
+// class (which feeds \date into pdfcreationdate). A free-form or empty date
+// leaves the PDF date at `auto` (the compile date), as the class does.
+#let parse-date(date) = {
+  let m = date.trim().match(regex("^(\d{1,2})\.(\d{1,2})\.(\d{4})$"))
+  if m == none {
+    auto
+  } else {
+    datetime(
+      day: int(m.captures.at(0)),
+      month: int(m.captures.at(1)),
+      year: int(m.captures.at(2)),
+    )
+  }
+}
+
 #let sfs-document(
   doctype: "",
   title: "",
@@ -123,6 +140,7 @@
     title: title,
     author: if author != none { author } else { () },
     keywords: if keywords != none { keywords } else { () },
+    date: parse-date(date),
   )
   set page(
     width: 210mm,
@@ -156,6 +174,17 @@
   // Smart quotes: Finnish convention is ” on both sides, ’ for inner quotes.
   set smartquote(quotes: (single: ("’", "’"), double: ("”", "”")))
 
+  // Figures and tables stay in the text flow, left-aligned at the body column
+  // like the rest of the content (cls \captionof, 6.5). The Finnish supplement
+  // (Taulukko/Kuva) comes from lang fi; the label separator is a quad with no
+  // colon, as in the class's caption style. Table captions sit above the table
+  // (6.5.1), image captions below it (6.5.2).
+  show figure: set align(left)
+  show figure: set block(spacing: parskip)
+  set figure.caption(separator: [#h(1em)])
+  show figure.where(kind: table): set figure.caption(position: top)
+  show figure.caption: set text(hyphenate: false)
+
   // Body text sits at the 43 mm column (the page's left margin). Margin-hanging
   // elements (headings, marginlabels) outdent by `column`; the extra metadata
   // area is offset to the 112 mm column.
@@ -167,19 +196,30 @@
   block(text(size: fontsize + 3pt, weight: "bold", hyphenate: false, title))
 
   if toc {
+    // The TOC heading stays on a line of its own (cls \tableofcontents,
+    // 6.10), hanging at the 20 mm margin like a display heading.
+    block(above: 1.5 * parskip, below: parskip, pad(left: -column, strong[Sisällys]))
     outline(title: none)
   }
 
   body
 
   if attachments != none or distribution != none or forinformation != none {
-    if endmatter-newpage { pagebreak() }
+    if endmatter-newpage {
+      pagebreak()
+    } else {
+      // One extra paragraph gap separates the end matter from the preceding
+      // content when it is not on a fresh page (cls \sfs@marginlist, 6.7).
+      v(parskip, weak: true)
+    }
     if attachments != none { marginlabel([Liitteet], attachments) }
     if distribution != none { marginlabel([Jakelu], distribution) }
     if forinformation != none { marginlabel([Tiedoksi], forinformation) }
   }
 
   if contact != none {
-    block(above: parskip)[#strong(contact.at("name", default: "")) \ #contact.at("lines", default: "")]
+    // The organisation contact area hangs at the 20 mm margin, separated by an
+    // extra paragraph gap (cls \makecontactinfo).
+    block(above: 2 * parskip, pad(left: -column)[#strong(contact.at("name", default: "")) \ #contact.at("lines", default: "")])
   }
 }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -73,13 +73,20 @@ main {
   overflow: auto;
   background: #e0e0e0;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
   padding: 1rem;
 }
 
-#preview svg {
-  width: 100%;
+/* Each page is its own sheet: shown at its natural size, scaled down to fit a
+   narrow pane (never blown up past the real page width), white with a drop
+   shadow on the grey backdrop. */
+#preview svg.page {
+  display: block;
+  width: auto;
   height: auto;
+  max-width: 100%;
   background: #fff;
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.3);
 }

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -5,3 +5,9 @@ declare module "markdown-it-deflist" {
   const plugin: (md: MarkdownIt) => void;
   export default plugin;
 }
+
+declare module "markdown-it-footnote" {
+  import type MarkdownIt from "markdown-it";
+  const plugin: (md: MarkdownIt) => void;
+  export default plugin;
+}


### PR DESCRIPTION
## Summary

Extends the Markdown-to-Typst converter to support footnotes, pipe tables with captions, and captioned image figures, bringing feature parity closer to the pandoc/LaTeX pipeline. Also improves the live preview rendering to display multi-page documents as individual sheets instead of one fused tall SVG.

## Key Changes

**Markdown Converter (`md-to-typst.ts`)**
- Added `markdown-it-footnote` plugin to parse reference and inline footnotes
- Implemented footnote rendering: stores footnote content in parse environment and resolves `footnote_ref` tokens to `#footnote[…]` calls
- Added pipe table support with `table()` function that generates Typst `#table(…)` with booktabs-style rules and column alignment from markdown delimiters
- Implemented table captions: paragraphs matching pandoc style (`": Caption"` or `"Table: Caption"`) are held back and wrapped with the following table in `#figure(…, kind: table)`
- Added implicit figure support: paragraphs containing only an image become `#figure(image(…), caption: […], kind: image)` with alt text as caption
- Enhanced heading parsing to recognize pandoc attributes (`{-}`, `{.unnumbered}`, `{#id}`) and emit unnumbered headings via `#heading(level: …, numbering: none)[…]`
- Added helper functions: `renderNote()` to handle block vs. inline footnote content, `nextBlockIsTable()` to lookahead for table detection

**Template (`sfs-2487-2024.typ`)**
- Added `parse-date()` function to parse document date from `d.m.yyyy` format into `datetime` for PDF metadata
- Set document metadata including parsed date (becomes PDF CreationDate/ModDate)
- Configured figure and table styling: left-aligned, proper spacing, Finnish captions (Taulukko/Kuva), table captions positioned above, image captions below
- Updated TOC rendering with proper heading and margin hanging
- Improved end-matter and contact info spacing and alignment

**Live Preview (`main.ts`)**
- Added `showPages()` function to split single-SVG output from typst.ts into one cropped `<svg>` per page
- Each page is rendered at natural size, scaled to fit the preview pane, with proper aspect ratio and overflow clipping
- Removes embedded `<script>` tags before cloning to avoid duplicate global declarations

**Styling (`style.css`)**
- Updated preview layout to flex column with centered alignment and gap between pages
- Styled individual page SVGs: `width: auto`, `max-width: 100%`, white background with drop shadow

**Type Declarations (`vite-env.d.ts`)**
- Added module declaration for `markdown-it-footnote`

**Dependencies (`package.json`)**
- Added `markdown-it-footnote@^4.0.0`

## Notable Implementation Details

- Footnote environment is thread-safe via try/finally: stores and restores previous state around `blocks()` call
- Table caption detection uses lookahead to distinguish caption paragraphs from regular text
- Heading attributes are stripped from rendered body text to avoid duplication in output
- Multi-page preview now displays as a scrollable column of properly-proportioned sheets instead of a single tall fused image, improving readability and matching typical document viewer UX

https://claude.ai/code/session_01EmDzq62p3TBFybXYWBnTG9