### PR TITLE
web: match LaTeX top margin, font sizes and vertical spacing in the t…

### DIFF
--- a/web/src/sfs-2487-2024.typ
+++ b/web/src/sfs-2487-2024.typ
@@ -19,7 +19,14 @@
 #let meta-offset = metaindent - column // 69 mm: from the 43 mm body column
 #let metawidth = 88mm // 200 mm right text edge − 112 mm
 #let logo-max-height = 20mm
-#let parskip = 11.6pt // paragraph gap (.88 baselineskip at 11 pt)
+#let header-top = 14.4mm // top margin above the metadata block (cls geometry top)
+#let leading = 5.2pt // within-paragraph line gap (→ 13.2 pt baseline at 11 pt)
+#let parskip = 11.6pt // LaTeX paragraph gap (kappaleväli, .88 baselineskip)
+// Typst measures block spacing between bounding boxes, whereas LaTeX adds the
+// paragraph gap on top of a full baselineskip; a block gap is therefore short
+// by one `leading` and the standard one-paragraph-gap between blocks is
+// parskip + leading. `n * parskip + leading` keeps n-paragraph-gap spacings.
+#let blockgap = parskip + leading
 #let runin-sep = 0.5em // minimum gap kept when a heading/label runs in
 
 // Metric-compatible stand-ins for the class's Type 1 fonts (Typst cannot use
@@ -44,12 +51,12 @@
 // indent; otherwise the label takes its own line with the body below.
 #let marginlabel(label, body) = context {
   if runin-state.get() and body != [] and fits-column(label) {
-    block(spacing: parskip, {
+    block(spacing: blockgap, {
       place(top + left, dx: -column, box(width: column, label))
       body
     })
   } else {
-    block(below: parskip, pad(left: -column, label))
+    block(below: blockgap, pad(left: -column, label))
     body
   }
 }
@@ -58,13 +65,13 @@
 #let esignatures(sentence, ..signees) = {
   block(sentence)
   for s in signees.pos() {
-    block(below: 0pt, above: parskip)[#s.at(0) \ #s.at(1)]
+    block(below: 0pt, above: blockgap)[#s.at(0) \ #s.at(1)]
   }
 }
 
 // A line printed under reserved space for a handwritten signature
 // (cls \handsignature: three paragraph gaps above the printed line).
-#let handsignature(line) = block(above: 3 * parskip, below: 0pt, line)
+#let handsignature(line) = block(above: 3 * parskip + leading, below: 0pt, line)
 
 // The document date (6.2) is given in the standard's d.m.yyyy form. Parse it
 // into a `datetime` so it becomes the PDF CreationDate/ModDate, matching the
@@ -100,7 +107,9 @@
   forinformation: none,
   keywords: none,
   font: "sans-serif",
-  fontsize: 11pt,
+  // The LaTeX 11pt article class sets \normalsize to 10.9091pt (\@xipt), so the
+  // metric-compatible body text matches when measured with mutool.
+  fontsize: 10.9091pt,
   agenda: false,
   toc: false,
   runin: true,
@@ -116,7 +125,7 @@
     if logo != none {
       // Hang the logo in the 20 mm margin, capped at logo-max-height: scale
       // down only when taller than the cap, never up (cls \logomaxheight).
-      place(top + left, dx: -column, context {
+      place(top + left, dx: -column, dy: header-top, context {
         if measure(logo).height > logo-max-height {
           box(height: logo-max-height, logo)
         } else {
@@ -127,6 +136,7 @@
     place(
       top + left,
       dx: meta-offset,
+      dy: header-top,
       box(width: metawidth)[
         #strong(doctype) #h(1fr) #context counter(page).display("1 (1)", both: true) \
         #date
@@ -145,13 +155,17 @@
   set page(
     width: 210mm,
     height: 297mm,
-    margin: (left: body-indent, right: 10mm, top: 33mm, bottom: 20mm),
-    header-ascent: 23mm,
+    // top: leaves room for the 14.4 mm top margin, the metadata block and a
+    // headsep gap so the body starts where the class puts it (~42 mm).
+    margin: (left: body-indent, right: 10mm, top: 42mm, bottom: 20mm),
+    // The metadata block is placed absolutely from the page top (header-top),
+    // so the header region spans the whole top margin to contain it.
+    header-ascent: 42mm,
     header: metadata-block,
   )
   set text(font: body-font, size: fontsize, lang: "fi", hyphenate: true)
   // linespread 0.9706 in the class → 13.2 pt leading at 11 pt; parskip 11.6 pt.
-  set par(leading: 5.2pt, spacing: parskip, justify: false, first-line-indent: 0pt)
+  set par(leading: leading, spacing: blockgap, justify: false, first-line-indent: 0pt)
   set list(marker: [–], indent: 0pt) // Finnish convention: en dash, flush at body indent
   set enum(indent: 0pt)
   set heading(numbering: if agenda { "1.1.1." } else { "1.1.1" })
@@ -161,13 +175,16 @@
   // following body line (cls run-in/display machinery); the run-in heading is
   // laid out with zero height so the next paragraph rises beside it.
   show heading: it => context {
-    set text(weight: "bold", hyphenate: false)
+    // Keep headings at body size (cls: bold normalsize); without an explicit
+    // size Typst's default per-level scaling (1.4em at level 1, …) would make
+    // them far larger than the standard's bold-at-body-size headings (6.4).
+    set text(size: fontsize, weight: "bold", hyphenate: false)
     let head = if it.numbering != none [#counter(heading).display() #it.body] else [#it.body]
-    let above = if it.level == 1 { 1.5 * parskip } else { parskip }
+    let above = if it.level == 1 { 1.5 * parskip + leading } else { blockgap }
     if runin and fits-column(head) {
       block(above: above, below: 0pt, height: 0pt, place(top + left, dx: -column, box(width: column, head)))
     } else {
-      block(above: above, below: parskip, pad(left: -column, head))
+      block(above: above, below: blockgap, pad(left: -column, head))
     }
   }
 
@@ -180,7 +197,7 @@
   // colon, as in the class's caption style. Table captions sit above the table
   // (6.5.1), image captions below it (6.5.2).
   show figure: set align(left)
-  show figure: set block(spacing: parskip)
+  show figure: set block(spacing: blockgap)
   set figure.caption(separator: [#h(1em)])
   show figure.where(kind: table): set figure.caption(position: top)
   show figure.caption: set text(hyphenate: false)
@@ -192,13 +209,18 @@
     block(pad(left: meta-offset, extrametadata))
   }
   if recipient != none { block(recipient) }
-  if subject != none { block(below: 0pt, strong(subject)) }
-  block(text(size: fontsize + 3pt, weight: "bold", hyphenate: false, title))
+  // Subject and title share one block with the title leading between them, as
+  // the class typesets them in a single parbox (5.2); the title is the
+  // document's level-1 heading, bold and 3 pt larger (5.2.1).
+  block(below: 1.5 * parskip, {
+    if subject != none { strong(subject); linebreak() }
+    text(size: fontsize + 3pt, weight: "bold", hyphenate: false, title)
+  })
 
   if toc {
     // The TOC heading stays on a line of its own (cls \tableofcontents,
     // 6.10), hanging at the 20 mm margin like a display heading.
-    block(above: 1.5 * parskip, below: parskip, pad(left: -column, strong[Sisällys]))
+    block(above: 1.5 * parskip, below: blockgap, pad(left: -column, strong[Sisällys]))
     outline(title: none)
   }
 
@@ -209,8 +231,9 @@
       pagebreak()
     } else {
       // One extra paragraph gap separates the end matter from the preceding
-      // content when it is not on a fresh page (cls \sfs@marginlist, 6.7).
-      v(parskip, weak: true)
+      // content when it is not on a fresh page (cls \sfs@marginlist, 6.7); a
+      // non-weak space so it adds on top of the label block's own gap.
+      v(parskip)
     }
     if attachments != none { marginlabel([Liitteet], attachments) }
     if distribution != none { marginlabel([Jakelu], distribution) }
@@ -220,6 +243,6 @@
   if contact != none {
     // The organisation contact area hangs at the 20 mm margin, separated by an
     // extra paragraph gap (cls \makecontactinfo).
-    block(above: 2 * parskip, pad(left: -column)[#strong(contact.at("name", default: "")) \ #contact.at("lines", default: "")])
+    block(above: 2 * parskip + leading, pad(left: -column)[#strong(contact.at("name", default: "")) \ #contact.at("lines", default: "")])
   }
 }


### PR DESCRIPTION
…ypst layout

Bring the typst.ts layout closer to the reference LaTeX class on the two reported gaps, plus the vertical rhythm they exposed (verified with pdftotext -bbox and mutool against the pinned TeX Live build).

- Top margin: the metadata block was placed at the page top edge (yMin ≈ 0) because place(top + left) anchors to the page top, ignoring header-ascent. Offset it down by header-top (14.4 mm) and raise margin.top to 42 mm so the block sits at ~40 pt and the body starts where the class puts it — matching LaTeX within ~1 pt on both pages.

- Font sizes: set the base size to 10.9091 pt (the LaTeX 11 pt class's \@xipt), and pin heading text to the body size in the show rule — Typst's default per-level scaling was rendering headings at 15.4 pt (1.4 em) instead of the standard's bold-at-body-size (6.4). Body, headings and the +3 pt title now measure identically to the LaTeX output.

- Vertical spacing: Typst measures block gaps between bounding boxes while LaTeX adds parskip on top of a full baselineskip, so every inter-block gap was short by one leading and the page crept upward (~55 pt by the signatures). Introduce blockgap = parskip + leading for block spacings, and render the subject and title in one block like the class's title parbox; the whole page now tracks LaTeX within ~2 pt.