### PR TITLE
Add preview zoom/fit controls, two-page toggle, and a movable divider to the web editor

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -74,6 +74,20 @@ short line that a long error can never reflow):
   right**; the status bar itself only ever shows the short compile state
   (`käännetty`, `virhe`, …), so it never grows or reflows.
 
+## Preview controls
+
+The preview pane has a toolbar with the usual document-viewer controls, plus a
+draggable divider between the editor and the preview:
+
+- **−/+** zoom out/in (with a percentage readout), **Sovita leveyteen** /
+  **Sovita korkeuteen** fit the page width / a whole page to the pane (and
+  re-fit live as the pane resizes), and **Kaksi sivua** toggles a two-page
+  spread.
+- Drag the bar between the editor and preview to rebalance them (arrow keys
+  nudge it when focused).
+- The zoom/fit mode, the one/two-page choice and the divider position are
+  autosaved to `localStorage` alongside the document.
+
 ## Verification
 
 The layout is checked exactly the way the LaTeX class is, with

--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,18 @@
     </header>
     <main>
       <div id="editor" aria-label="Markdown"></div>
-      <div id="preview" aria-label="Esikatselu"></div>
+      <div id="divider" role="separator" aria-orientation="vertical" aria-label="Siirrä jakajaa" tabindex="0"></div>
+      <section id="preview-pane">
+        <div id="preview-toolbar">
+          <button id="zoom-out" title="Loitonna" aria-label="Loitonna">−</button>
+          <span id="zoom-level" aria-live="polite">100 %</span>
+          <button id="zoom-in" title="Lähennä" aria-label="Lähennä">+</button>
+          <button id="fit-width" title="Sovita sivun leveys näkymään">Sovita leveyteen</button>
+          <button id="fit-height" title="Sovita koko sivu näkymään">Sovita korkeuteen</button>
+          <button id="two-up" aria-pressed="false" title="Näytä kaksi sivua rinnakkain">Kaksi sivua</button>
+        </div>
+        <div id="preview" aria-label="Esikatselu"><div id="pages"></div></div>
+      </section>
     </main>
     <footer id="statusbar">
       <div class="bar-left">

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -44,12 +44,22 @@ $typst.setRendererInitOptions({ getModule: () => rendererWasmUrl });
 const statusEl = document.getElementById("status")!;
 const downloadEl = document.getElementById("download") as HTMLButtonElement;
 const previewEl = document.getElementById("preview")!;
+const pagesEl = document.getElementById("pages")!;
 const logoEl = document.getElementById("logo") as HTMLInputElement;
 const logoClearEl = document.getElementById("logo-clear") as HTMLButtonElement;
 const vimEl = document.getElementById("vim") as HTMLInputElement;
 const vimModeEl = document.getElementById("vim-mode")!;
 const resetEl = document.getElementById("reset") as HTMLButtonElement;
 const toastsEl = document.getElementById("toasts")!;
+const mainEl = document.querySelector("main")!;
+const editorEl = document.getElementById("editor")!;
+const dividerEl = document.getElementById("divider")!;
+const zoomInEl = document.getElementById("zoom-in") as HTMLButtonElement;
+const zoomOutEl = document.getElementById("zoom-out") as HTMLButtonElement;
+const zoomLevelEl = document.getElementById("zoom-level")!;
+const fitWidthEl = document.getElementById("fit-width") as HTMLButtonElement;
+const fitHeightEl = document.getElementById("fit-height") as HTMLButtonElement;
+const twoUpEl = document.getElementById("two-up") as HTMLButtonElement;
 
 function setStatus(text: string, error = false) {
   statusEl.textContent = text;
@@ -87,7 +97,8 @@ function showPages(svgText: string) {
   holder.innerHTML = svgText;
   const base = holder.querySelector("svg");
   if (!base) {
-    previewEl.innerHTML = svgText;
+    pageSizes = [];
+    pagesEl.innerHTML = svgText;
     return;
   }
   // typst.ts embeds a <script> for interactivity; cloned once per page it would
@@ -96,10 +107,12 @@ function showPages(svgText: string) {
   base.querySelectorAll("script").forEach((s) => s.remove());
   const pages = Array.from(base.querySelectorAll("g.typst-page"));
   if (pages.length === 0) {
-    previewEl.replaceChildren(base);
+    pageSizes = [];
+    pagesEl.replaceChildren(base);
     return;
   }
   const cards: SVGSVGElement[] = [];
+  const sizes: { w: number; h: number }[] = [];
   for (const page of pages) {
     const t = (page.getAttribute("transform") ?? "").match(/translate\(\s*([-\d.]+)[,\s]+([-\d.]+)/);
     const y = t ? parseFloat(t[2]) : 0;
@@ -109,23 +122,30 @@ function showPages(svgText: string) {
     // Crop to this page's slice; clip to it (typst sets overflow:visible, which
     // would otherwise leak the other pages into the view).
     card.setAttribute("viewBox", `0 ${y} ${w} ${h}`);
-    card.setAttribute("width", String(w));
-    card.setAttribute("height", String(h));
     card.setAttribute("preserveAspectRatio", "xMidYMid meet");
     card.style.overflow = "hidden";
     card.removeAttribute("data-width");
     card.removeAttribute("data-height");
     card.classList.add("page");
     cards.push(card);
+    sizes.push({ w, h }); // natural page size in pt; the zoom/fit logic sizes the element
   }
-  previewEl.replaceChildren(...cards);
+  pageSizes = sizes;
+  pagesEl.replaceChildren(...cards);
+  applyView();
 }
 
 // --- localStorage persistence (document, logo, vim toggle) ---
 // The editor is otherwise stateless, so a reload would lose work; these survive
 // it. Every access is guarded so a disabled or full localStorage never breaks
 // the editor — persistence is best-effort.
-const STORE = { doc: "sfs2487.doc", logo: "sfs2487.logo", vim: "sfs2487.vim" };
+const STORE = {
+  doc: "sfs2487.doc",
+  logo: "sfs2487.logo",
+  vim: "sfs2487.vim",
+  view: "sfs2487.view",
+  split: "sfs2487.split",
+};
 
 interface StoredLogo { path: string; name: string; b64: string }
 
@@ -380,6 +400,129 @@ resetEl.addEventListener("click", async () => {
   lsRemove(STORE.doc);
   render(fresh);
 });
+
+// --- preview view controls: zoom, fit-to-pane, one/two pages, split divider ---
+
+interface ViewPrefs {
+  zoom: number; // explicit scale when fit === "none" (1 = natural pt → px)
+  fit: "none" | "width" | "height";
+  twoUp: boolean;
+}
+let view: ViewPrefs = { zoom: 1, fit: "width", twoUp: false };
+// Natural page sizes (pt) recorded by showPages; the fit math scales from these.
+let pageSizes: { w: number; h: number }[] = [];
+
+const ZOOM_MIN = 0.1;
+const ZOOM_MAX = 5;
+const ZOOM_STEP = 1.25;
+const PAGE_GAP = 16; // px, matches #pages `gap: 1rem`
+
+const clampZoom = (z: number) => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z));
+
+function saveView() {
+  lsSet(STORE.view, JSON.stringify(view));
+}
+
+// The zoom that fits the page(s) to the pane in the active fit mode.
+function fitZoom(): number {
+  const page = pageSizes[0];
+  if (!page) return view.zoom;
+  const cs = getComputedStyle(previewEl);
+  if (view.fit === "width") {
+    const avail = previewEl.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+    const per = view.twoUp ? (avail - PAGE_GAP) / 2 : avail;
+    return clampZoom(per / page.w);
+  }
+  if (view.fit === "height") {
+    const avail = previewEl.clientHeight - parseFloat(cs.paddingTop) - parseFloat(cs.paddingBottom);
+    return clampZoom(avail / page.h);
+  }
+  return view.zoom;
+}
+
+const currentZoom = () => (view.fit === "none" ? view.zoom : fitZoom());
+
+function applyView() {
+  pagesEl.classList.toggle("two-up", view.twoUp);
+  twoUpEl.setAttribute("aria-pressed", String(view.twoUp));
+  const z = currentZoom();
+  const cards = pagesEl.querySelectorAll<SVGSVGElement>("svg.page");
+  cards.forEach((card, i) => {
+    const s = pageSizes[i] ?? pageSizes[0];
+    if (!s) return;
+    card.style.width = `${s.w * z}px`;
+    card.style.height = `${s.h * z}px`;
+  });
+  zoomLevelEl.textContent = `${Math.round(z * 100)} %`;
+}
+
+function setZoom(z: number) {
+  view.fit = "none";
+  view.zoom = clampZoom(z);
+  saveView();
+  applyView();
+}
+
+zoomInEl.addEventListener("click", () => setZoom(currentZoom() * ZOOM_STEP));
+zoomOutEl.addEventListener("click", () => setZoom(currentZoom() / ZOOM_STEP));
+fitWidthEl.addEventListener("click", () => { view.fit = "width"; saveView(); applyView(); });
+fitHeightEl.addEventListener("click", () => { view.fit = "height"; saveView(); applyView(); });
+twoUpEl.addEventListener("click", () => { view.twoUp = !view.twoUp; saveView(); applyView(); });
+
+// Re-fit when the pane changes size (window resize, divider drag) in a fit mode.
+new ResizeObserver(() => { if (view.fit !== "none") applyView(); }).observe(previewEl);
+
+// Movable divider: --split holds the editor width (px); the grid gives the rest
+// to the preview. Clamp so neither pane collapses.
+function setSplit(px: number) {
+  const min = 150;
+  const max = mainEl.clientWidth - 150 - 6; // leave room for the preview + divider
+  mainEl.style.setProperty("--split", `${Math.min(max, Math.max(min, px))}px`);
+}
+function persistSplit() {
+  lsSet(STORE.split, mainEl.style.getPropertyValue("--split").replace("px", "").trim());
+}
+
+dividerEl.addEventListener("pointerdown", (e) => {
+  e.preventDefault();
+  dividerEl.setPointerCapture(e.pointerId);
+  const onMove = (ev: PointerEvent) => setSplit(ev.clientX - mainEl.getBoundingClientRect().left);
+  const onUp = () => {
+    dividerEl.releasePointerCapture(e.pointerId);
+    dividerEl.removeEventListener("pointermove", onMove);
+    dividerEl.removeEventListener("pointerup", onUp);
+    persistSplit();
+  };
+  dividerEl.addEventListener("pointermove", onMove);
+  dividerEl.addEventListener("pointerup", onUp);
+});
+
+// Keyboard a11y: arrow keys nudge the focused divider.
+dividerEl.addEventListener("keydown", (e) => {
+  if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+  e.preventDefault();
+  setSplit(editorEl.clientWidth + (e.key === "ArrowLeft" ? -24 : 24));
+  persistSplit();
+});
+
+// Keep the split within bounds when the window shrinks.
+window.addEventListener("resize", () => {
+  const cur = mainEl.style.getPropertyValue("--split");
+  if (cur) setSplit(parseFloat(cur));
+});
+
+// Restore saved view preferences and divider position.
+const savedView = lsGet(STORE.view);
+if (savedView) {
+  try {
+    view = { ...view, ...JSON.parse(savedView) };
+  } catch {
+    lsRemove(STORE.view);
+  }
+}
+const savedSplit = lsGet(STORE.split);
+if (savedSplit) setSplit(parseFloat(savedSplit));
+applyView();
 
 setStatus("alustetaan typst.ts…");
 render(editor.state.doc.toString());

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -29,12 +29,13 @@ header {
 main {
   flex: 1 1 auto;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  /* editor | draggable divider | preview pane. --split (an editor px width) is
+     set while dragging #divider; the 1fr default keeps the initial 50/50. */
+  grid-template-columns: var(--split, 1fr) 6px 1fr;
   min-height: 0;
 }
 
 #editor {
-  border-right: 1px solid #ccc;
   overflow: auto;
 }
 
@@ -42,24 +43,84 @@ main {
   height: 100%;
 }
 
-#preview {
-  overflow: auto;
-  background: #e0e0e0;
+#divider {
+  background: #ccc;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+#divider:hover,
+#divider:focus-visible {
+  background: #90a4ae;
+  outline: none;
+}
+
+#preview-pane {
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+#preview-toolbar {
+  flex: 0 0 auto;
+  display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.4rem;
+  padding: 0.35rem 0.6rem;
+  background: #455a64;
+  color: #fff;
+  font-size: 0.85rem;
+}
+
+#preview-toolbar button {
+  font: inherit;
+}
+
+#preview-toolbar #zoom-out,
+#preview-toolbar #zoom-in {
+  width: 1.8rem;
+}
+
+#zoom-level {
+  min-width: 4.5ch;
+  text-align: center;
+}
+
+#two-up {
+  margin-left: 0.4rem;
+}
+
+#two-up[aria-pressed="true"] {
+  background: #cfd8dc;
+  font-weight: bold;
+}
+
+#preview {
+  flex: 1 1 auto;
+  overflow: auto;
+  background: #e0e0e0;
   padding: 1rem;
 }
 
-/* Each page is its own sheet: shown at its natural size, scaled down to fit a
-   narrow pane (never blown up past the real page width), white with a drop
-   shadow on the grey backdrop. */
-#preview svg.page {
+/* One page per row by default; the two-up toggle puts pages two per row as a
+   spread. `safe center` keeps a zoomed page that is wider than the pane from
+   being clipped on the left (so it stays scrollable). */
+#pages {
+  display: grid;
+  grid-template-columns: max-content;
+  justify-content: safe center;
+  gap: 1rem;
+}
+
+#pages.two-up {
+  grid-template-columns: repeat(2, max-content);
+}
+
+/* Each page is its own white sheet with a drop shadow on the grey backdrop; its
+   pixel size is set on the element by the zoom/fit logic. */
+#pages svg.page {
   display: block;
-  width: auto;
-  height: auto;
-  max-width: 100%;
   background: #fff;
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
## Summary

Gives the typst.ts web editor's preview pane the usual document-viewer ergonomics. Each page card is now sized explicitly in pixels by a zoom/fit layer (replacing the old CSS `max-width` fit), pages lay out one- or two-up via a grid on `#pages`, and the editor/preview split is draggable.

No new dependencies — pure DOM + CSS — so `flake.nix`'s `npmDepsHash` is unchanged.

## Changes

- **Preview toolbar** (`index.html`, `style.css`): zoom out/in buttons with a percentage readout, **Sovita leveyteen** (fit width) / **Sovita korkeuteen** (fit height), and a **Kaksi sivua** (two-page) toggle.
- **View logic** (`main.ts`): a `ViewPrefs` state (`zoom`, `fit`, `twoUp`), `applyView()` that sizes each page card, and `fitZoom()` that computes the fit-to-pane scale. A `ResizeObserver` on the preview re-fits live on window resize and divider drag.
- **Movable divider**: a CSS grid `--split` var holds the editor width; pointer drag sets it (clamped so neither pane collapses), and arrow keys nudge the focused divider for keyboard access.
- **`showPages`** records each page's natural pt size and appends cards into `#pages`, then calls `applyView()`.
- **Persistence**: the zoom/fit mode, one/two-page choice and divider position are autosaved to `localStorage` alongside the document.
- **Docs**: a "Preview controls" section in `web/README.md`.

## Verification

- `npm run build` (tsc + vite) and `nix build .#web` both pass.
- Headless Chromium checks: default fit-width fills the pane, zoom in/out scale the page, fit-height fits a whole page tall, the two-page toggle yields a two-column spread (`#pages.two-up`, `aria-pressed`), dragging the divider resizes the editor, and the zoom/fit/two-up/split state persists across a reload.
- The existing `scripts/smoke.mjs` still reaches status `käännetty` with the multi-page preview intact.

https://claude.ai/code/session_018TYUepFkK9mdn6DjgH89Ty

---
_Generated by [Claude Code](https://claude.ai/code/session_018TYUepFkK9mdn6DjgH89Ty)_