### PR TITLE
web: bottom status bar with Vim mode badge, visible selection, and error toasts

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -52,15 +52,27 @@ generated Typst for one document (used by the verification below).
 
 ## Editor controls
 
-- **Vim** — a checkbox toggling Vim keybindings
+The controls sit in a **bottom status bar** (so the top bar stays a single
+short line that a long error can never reflow):
+
+- **Vim** (bottom left) — a checkbox toggling Vim keybindings
   ([@replit/codemirror-vim](https://github.com/replit/codemirror-vim)) in the
-  CodeMirror editor, switched live via a `Compartment`.
-- **Uusi esimerkki** — resets the document back to the seeded example and clears
-  the uploaded logo (the Vim toggle is kept — it is an editor preference).
+  CodeMirror editor, switched live via a `Compartment`. When Vim is on, a badge
+  next to it shows the current mode (`NORMAL` / `INSERT` / `VISUAL` …), driven by
+  the extension's `vim-mode-change` event. The editor enables CodeMirror's
+  `drawSelection()` — which the Vim extension needs to paint the visual-mode
+  selection — and themes the painted selection a clearly visible blue so
+  selected text stands out, focused or not.
+- **Logo / Poista logo / Uusi esimerkki / Lataa PDF** (bottom right) — logo
+  upload, document/logo reset back to the seeded example (the Vim toggle is
+  kept — it is an editor preference), and PDF download.
 - The document, the uploaded logo and the Vim toggle are autosaved to the
   browser's `localStorage` and restored on reload. (A restored logo cannot
   repopulate the file input, so the **Poista logo** button — with the file name
   as its tooltip — is the "a logo is loaded" indicator.)
+- Conversion and compile **errors appear as dismissible toasts at the bottom
+  right**; the status bar itself only ever shows the short compile state
+  (`käännetty`, `virhe`, …), so it never grows or reflows.
 
 ## Verification
 
@@ -97,6 +109,12 @@ npm install --no-save puppeteer-core
 CHROMIUM=/path/to/chromium DOWNLOAD_DIR=/tmp/dl node scripts/smoke.mjs
 pdftotext -bbox /tmp/dl/* -
 ```
+
+A companion `scripts/verify-ui.mjs` (same Chromium + `puppeteer-core` setup)
+checks the editor chrome rather than the layout: that the controls live in the
+bottom status bar, the Vim mode badge tracks `NORMAL` → `VISUAL`, the
+visual-mode selection is painted in a visible colour, and a conversion error
+surfaces as a bottom-right toast without reflowing the header.
 
 That smoke test caught one real issue the CLI could not: by default typst.ts
 fetches its built-in fonts from a CDN (jsdelivr), which breaks offline /

--- a/web/index.html
+++ b/web/index.html
@@ -8,19 +8,27 @@
   <body>
     <header>
       <strong>SFS 2487:2024</strong> – Markdown → PDF (typst.ts-prototyyppi)
-      <label id="vim-label"><input id="vim" type="checkbox" /> Vim</label>
-      <button id="reset">Uusi esimerkki</button>
-      <label id="logo-label">Logo
-        <input id="logo" type="file" accept="image/png,image/jpeg,image/svg+xml" />
-      </label>
-      <button id="logo-clear" hidden>Poista logo</button>
-      <button id="download" disabled>Lataa PDF</button>
-      <span id="status">ladataan…</span>
     </header>
     <main>
       <div id="editor" aria-label="Markdown"></div>
       <div id="preview" aria-label="Esikatselu"></div>
     </main>
+    <footer id="statusbar">
+      <div class="bar-left">
+        <label id="vim-label"><input id="vim" type="checkbox" /> Vim</label>
+        <span id="vim-mode" hidden></span>
+        <span id="status">ladataan…</span>
+      </div>
+      <div class="bar-right">
+        <label id="logo-label">Logo
+          <input id="logo" type="file" accept="image/png,image/jpeg,image/svg+xml" />
+        </label>
+        <button id="logo-clear" hidden>Poista logo</button>
+        <button id="reset">Uusi esimerkki</button>
+        <button id="download" disabled>Lataa PDF</button>
+      </div>
+    </footer>
+    <div id="toasts" aria-live="polite"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/web/scripts/verify-ui.mjs
+++ b/web/scripts/verify-ui.mjs
@@ -1,0 +1,99 @@
+// One-off manual UI check (not part of CI): verifies the bottom status bar,
+// the Vim mode indicator, the visible visual-mode selection, and that errors
+// surface as toasts. Run after `npm run build`:
+//   CHROMIUM=/path/to/chrome node scripts/verify-ui.mjs
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { extname, join, normalize } from "node:path";
+import puppeteer from "puppeteer-core";
+
+const DIST = new URL("../dist/", import.meta.url).pathname;
+const TYPES = {
+  ".html": "text/html", ".js": "text/javascript", ".css": "text/css",
+  ".wasm": "application/wasm", ".otf": "font/otf", ".svg": "image/svg+xml", ".json": "application/json",
+};
+const server = createServer(async (req, res) => {
+  let p = normalize(decodeURIComponent(req.url.split("?")[0]));
+  if (p === "/") p = "/index.html";
+  const file = join(DIST, p);
+  if (!existsSync(file)) { res.statusCode = 404; return res.end("not found"); }
+  res.setHeader("Content-Type", TYPES[extname(file)] ?? "application/octet-stream");
+  res.end(await readFile(file));
+});
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+
+const browser = await puppeteer.launch({
+  executablePath: process.env.CHROMIUM,
+  headless: true,
+  args: ["--no-sandbox", "--disable-gpu"],
+});
+const page = await browser.newPage();
+page.on("pageerror", (e) => console.error("PAGEERROR:", e.message));
+page.on("console", (m) => m.type() === "error" && console.error("CONSOLE:", m.text()));
+await page.goto(`http://localhost:${port}/`, { waitUntil: "load" });
+await page.waitForFunction(
+  () => document.getElementById("status")?.textContent === "käännetty",
+  { timeout: 120000 },
+);
+
+// Controls now live in the bottom status bar.
+const inBar = await page.$$eval("#statusbar button, #statusbar #vim-mode, #statusbar #vim",
+  (els) => els.map((e) => e.id));
+console.log("STATUSBAR_CONTROLS:", inBar.join(", "));
+
+async function dragSelectFirstLine() {
+  const box = await page.$eval(".cm-line", (e) => {
+    const r = e.getBoundingClientRect();
+    return { x: r.x, y: r.y + r.height / 2, w: r.width };
+  });
+  await page.mouse.move(box.x + 4, box.y);
+  await page.mouse.down();
+  await page.mouse.move(box.x + Math.min(120, box.w - 8), box.y, { steps: 8 });
+  await page.mouse.up();
+  await new Promise((r) => setTimeout(r, 120));
+}
+
+// Baseline: a plain mouse selection must be painted (drawSelection + theme).
+await dragSelectFirstLine();
+const plainSel = await page.$$eval(".cm-selectionBackground", (els) => els.map((e) => getComputedStyle(e).backgroundColor));
+console.log("PLAIN_SELECTION_BACKGROUNDS:", JSON.stringify(plainSel));
+
+// Enable Vim and check the mode badge appears as NORMAL.
+await page.click("#vim");
+await page.click(".cm-content"); // focus the editor
+await new Promise((r) => setTimeout(r, 100));
+const normal = await page.$eval("#vim-mode", (e) => ({ hidden: e.hidden, text: e.textContent, mode: e.dataset.mode }));
+console.log("VIM_MODE_NORMAL:", JSON.stringify(normal));
+
+// A mouse drag in Vim mode enters visual mode; the selection must be painted.
+await dragSelectFirstLine();
+const visual = await page.$eval("#vim-mode", (e) => ({ text: e.textContent, mode: e.dataset.mode }));
+const sel = await page.$$eval(".cm-selectionBackground", (els) =>
+  els.map((e) => getComputedStyle(e).backgroundColor),
+);
+console.log("VIM_MODE_VISUAL:", JSON.stringify(visual));
+console.log("SELECTION_BACKGROUNDS:", JSON.stringify(sel));
+
+// Trigger a conversion error and confirm it surfaces as a bottom-right toast,
+// while the header keeps its single short line (no reflow).
+const headerBefore = await page.$eval("header", (e) => e.getBoundingClientRect().height);
+await page.click("#vim"); // back to plain editing for a reliable select-all
+await page.click(".cm-content");
+await page.keyboard.down("Control");
+await page.keyboard.press("a");
+await page.keyboard.up("Control");
+await page.keyboard.type("---\nagenda: true\n---\n\nHei.\n");
+await new Promise((r) => setTimeout(r, 700));
+const toast = await page.evaluate(() => {
+  const t = document.querySelector("#toasts .toast");
+  return { count: document.querySelectorAll("#toasts .toast").length, text: t ? t.textContent.slice(0, 40) : null };
+});
+const headerAfter = await page.$eval("header", (e) => e.getBoundingClientRect().height);
+const status = await page.$eval("#status", (e) => e.textContent);
+console.log("TOAST:", JSON.stringify(toast));
+console.log("STATUS_AFTER_ERROR:", status);
+console.log("HEADER_HEIGHT_STABLE:", headerBefore === headerAfter, headerBefore, headerAfter);
+await browser.close();
+server.close();

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -5,11 +5,11 @@
 // compiled entirely in the browser by typst.ts: an SVG for the live preview
 // and a PDF for download. No server is involved.
 
-import { EditorView, keymap, lineNumbers } from "@codemirror/view";
+import { EditorView, keymap, lineNumbers, drawSelection } from "@codemirror/view";
 import { Compartment } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { markdown } from "@codemirror/lang-markdown";
-import { vim } from "@replit/codemirror-vim";
+import { vim, getCM } from "@replit/codemirror-vim";
 import { $typst } from "@myriaddreamin/typst.ts/dist/esm/contrib/snippet.mjs";
 import { preloadRemoteFonts } from "@myriaddreamin/typst.ts";
 
@@ -47,11 +47,32 @@ const previewEl = document.getElementById("preview")!;
 const logoEl = document.getElementById("logo") as HTMLInputElement;
 const logoClearEl = document.getElementById("logo-clear") as HTMLButtonElement;
 const vimEl = document.getElementById("vim") as HTMLInputElement;
+const vimModeEl = document.getElementById("vim-mode")!;
 const resetEl = document.getElementById("reset") as HTMLButtonElement;
+const toastsEl = document.getElementById("toasts")!;
 
 function setStatus(text: string, error = false) {
   statusEl.textContent = text;
   statusEl.classList.toggle("error", error);
+}
+
+// Errors land in a transient bottom-right toast instead of the status bar:
+// compiler messages can be long and multi-line, and inlining them would
+// reflow the bar. The status bar only ever shows the short compile state.
+function fail(message: string) {
+  setStatus("virhe", true);
+  const el = document.createElement("div");
+  el.className = "toast";
+  el.textContent = message;
+  el.title = "Sulje napsauttamalla";
+  const remove = () => el.remove();
+  el.addEventListener("click", remove);
+  // Auto-dismiss after a while; the fade is handled by the `.leaving` class.
+  window.setTimeout(() => {
+    el.classList.add("leaving");
+    window.setTimeout(remove, 300);
+  }, 10000);
+  toastsEl.appendChild(el);
 }
 
 // typst.ts returns a single SVG with all pages stacked seamlessly in one
@@ -196,7 +217,7 @@ async function render(md: string) {
   try {
     typst = markdownToTypst(md, { logoPath: logo?.path });
   } catch (e) {
-    setStatus(e instanceof ConversionError ? e.message : String(e), true);
+    fail(e instanceof ConversionError ? e.message : String(e));
     return;
   }
   currentTypst = typst;
@@ -213,7 +234,7 @@ async function render(md: string) {
     downloadEl.disabled = false;
     setStatus("käännetty");
   } catch (e) {
-    setStatus(String(e), true);
+    fail(String(e));
   }
 }
 
@@ -229,7 +250,7 @@ downloadEl.addEventListener("click", async () => {
     a.click();
     URL.revokeObjectURL(url);
   } catch (e) {
-    setStatus(String(e), true);
+    fail(String(e));
   }
 });
 
@@ -266,6 +287,20 @@ const vimCompartment = new Compartment();
 const vimEnabled = lsGet(STORE.vim) === "1";
 vimEl.checked = vimEnabled;
 
+// In Vim mode the @replit/codemirror-vim theme forces the browser's native
+// ::selection transparent and relies on drawSelection() to paint the visual
+// selection itself; without it, selected (visual-mode) text is invisible. The
+// theme gives the painted selection a clearly visible colour, focused or not.
+// The selectors mirror CodeMirror's own base theme (including the
+// `.cm-scroller > .cm-selectionLayer` child chain) so they match its
+// specificity and win — otherwise the faint default lavender shows through.
+const selectionTheme = EditorView.theme({
+  ".cm-selectionLayer .cm-selectionBackground": { backgroundColor: "#b3d4fc" },
+  "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground": {
+    backgroundColor: "#5b9dd9",
+  },
+});
+
 let timer: number | undefined;
 const editor = new EditorView({
   parent: document.getElementById("editor")!,
@@ -274,6 +309,8 @@ const editor = new EditorView({
     vimCompartment.of(vimEnabled ? vim() : []),
     lineNumbers(),
     history(),
+    drawSelection(),
+    selectionTheme,
     keymap.of([...defaultKeymap, ...historyKeymap]),
     markdown(),
     EditorView.lineWrapping,
@@ -287,11 +324,50 @@ const editor = new EditorView({
   ],
 });
 
+// Show the current Vim mode (NORMAL / INSERT / VISUAL …) on the left of the
+// status bar. The vim extension emits "vim-mode-change" on its CodeMirror-5
+// compatibility object; reconfiguring the compartment builds a fresh one, so
+// the listener is re-attached every time Vim is switched on.
+function vimModeLabel(mode: string, sub?: string): string {
+  if (mode === "visual") {
+    if (sub === "linewise") return "VISUAL LINE";
+    if (sub === "blockwise") return "VISUAL BLOCK";
+    return "VISUAL";
+  }
+  return mode.toUpperCase();
+}
+
+function showVimMode(mode: string, sub?: string) {
+  vimModeEl.hidden = false;
+  vimModeEl.textContent = vimModeLabel(mode, sub);
+  vimModeEl.dataset.mode = mode;
+}
+
+function syncVimMode() {
+  if (!vimEl.checked) {
+    vimModeEl.hidden = true;
+    return;
+  }
+  const cm = getCM(editor);
+  if (!cm) {
+    vimModeEl.hidden = true;
+    return;
+  }
+  // A freshly enabled Vim starts in normal mode without firing an event.
+  showVimMode("normal");
+  cm.on("vim-mode-change", (e: { mode: string; subMode?: string }) =>
+    showVimMode(e.mode, e.subMode),
+  );
+}
+
 vimEl.addEventListener("change", () => {
   editor.dispatch({ effects: vimCompartment.reconfigure(vimEl.checked ? vim() : []) });
   lsSet(STORE.vim, vimEl.checked ? "1" : "0");
+  syncVimMode();
   editor.focus();
 });
+
+syncVimMode();
 
 // Start over from the seeded example: reset the document and logo (and their
 // saved copies), but keep the Vim toggle — it is an editor preference, not part

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -14,6 +14,8 @@ body {
   flex-direction: column;
 }
 
+/* The top bar carries only the title now — the controls live in the bottom
+   status bar, so a long error message can no longer reflow it. */
 header {
   display: flex;
   gap: 1rem;
@@ -22,41 +24,6 @@ header {
   background: #37474f;
   color: #fff;
   flex: 0 0 auto;
-}
-
-/* Push the download button (and the status after it) to the right edge; the
-   logo controls stay next to the title on the left. */
-#download {
-  margin-left: auto;
-}
-
-#logo-label,
-#vim-label {
-  font-size: 0.85rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-#vim-label {
-  cursor: pointer;
-  user-select: none;
-}
-
-#logo-label input {
-  font-size: 0.8rem;
-  max-width: 20ch;
-}
-
-#status {
-  font-size: 0.85rem;
-  opacity: 0.85;
-  min-width: 12ch;
-}
-
-#status.error {
-  color: #ffcdd2;
-  white-space: pre-wrap;
 }
 
 main {
@@ -95,4 +62,109 @@ main {
   max-width: 100%;
   background: #fff;
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.3);
+}
+
+/* --- Bottom status bar / toolbar --- */
+#statusbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.3rem 1rem;
+  background: #263238;
+  color: #fff;
+  flex: 0 0 auto;
+  font-size: 0.85rem;
+  border-top: 1px solid #455a64;
+}
+
+#statusbar .bar-left,
+#statusbar .bar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+#vim-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+/* The current Vim mode, shown as a coloured badge only while Vim is on. */
+#vim-mode {
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  padding: 0.1rem 0.45rem;
+  border-radius: 0.2rem;
+  background: #546e7a;
+  color: #fff;
+}
+
+#vim-mode[data-mode="insert"] {
+  background: #2e7d32;
+}
+
+#vim-mode[data-mode="visual"] {
+  background: #ef6c00;
+}
+
+#vim-mode[data-mode="replace"] {
+  background: #c62828;
+}
+
+#status {
+  opacity: 0.8;
+  min-width: 10ch;
+}
+
+#status.error {
+  color: #ffcdd2;
+}
+
+#logo-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+#logo-label input {
+  font-size: 0.8rem;
+  max-width: 18ch;
+}
+
+/* --- Error toasts (bottom right) --- */
+#toasts {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: min(32rem, 90vw);
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  background: #b71c1c;
+  color: #fff;
+  padding: 0.6rem 0.8rem;
+  border-radius: 0.3rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  max-height: 40vh;
+  overflow: auto;
+  cursor: pointer;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.toast.leaving {
+  opacity: 0;
+  transform: translateX(1rem);
 }


### PR DESCRIPTION
## Summary

Reworks the browser editor chrome (`web/`) per the request:

- **Visible Vim selection.** The `@replit/codemirror-vim` theme forces the
  native `::selection` transparent and relies on CodeMirror's
  `drawSelection()` to paint the visual-mode selection — which the editor
  never enabled, so selected/painted text was indistinguishable from
  unselected. Enables `drawSelection()` and themes the painted selection a
  clearly visible blue (the selector mirrors the base theme's
  `.cm-scroller > .cm-selectionLayer` chain so it wins over the faint
  default lavender).
- **Bottom status bar / toolbar.** All controls moved out of the top bar
  into a new bottom bar: Vim toggle + a live **mode badge**
  (`NORMAL` / `INSERT` / `VISUAL` / `VISUAL LINE` …) on the left; logo,
  reset and download on the right. The top bar is now just the title.
- **Error toasts.** Conversion and compile errors now surface as
  dismissible bottom-right toasts; the status bar only ever shows the short
  compile state (`käännetty` / `virhe`), so it can no longer grow or reflow.

The mode badge is driven by the extension's `vim-mode-change` event, with the
listener re-attached whenever the Vim compartment is reconfigured.

## Verification

`npm run build` (tsc + vite) is clean. A headless Chromium check
(`web/scripts/verify-ui.mjs`, a companion to the existing smoke test)
confirms end to end:

- controls live in the bottom status bar (`vim`, `vim-mode`, `logo-clear`,
  `reset`, `download`);
- the mode badge tracks `NORMAL` → `VISUAL`;
- the visual-mode selection is painted `rgb(91, 157, 217)` (both plain and
  Vim selections), not the invisible/faint default;
- a conversion error appears as a bottom-right toast while the header height
  stays constant (35 → 35 px, no reflow) and the status shows the short
  `virhe`.

The PR's `smoke-test` CI check (`nix … make docs`) builds the web editor via
`nix build .#web`; only source files changed, so `npmDepsHash` is unaffected.

https://claude.ai/code/session_01PdiwSqT6wbs2zDoUsfD4M1

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdiwSqT6wbs2zDoUsfD4M1)_