### PR TITLE
Fix typst title indent and top margin; add logo→contact-name fallback

### DIFF
--- a/docs/latex.md
+++ b/docs/latex.md
@@ -91,12 +91,12 @@ from the output when unset.
 | `\docid{Dnro 123/2024}` | Asiakirjan yksilöivä tunnus | Optional |
 | `\confidentiality{Luottamuksellinen}` | Luottamuksellisuus | Optional |
 | `\extrametadata{Hankenumero 123456\\Asiakasnumero 987654}` | Lisämetatiedot | Optional; lines separated by `\\`, placed below the basic metadata |
-| `\logo{...}` | Logo / organisaatio | Any box: `\includegraphics{...}` or text such as `\textsf{\textbf{Yritys Oy}}`. Placed top-left; the page header grows automatically to fit a tall logo. A logo taller than `\logomaxheight` (20 mm by default) is scaled down proportionally — adjust with `\setlength{\logomaxheight}{30mm}` |
+| `\logo{...}` | Logo / organisaatio | Any box: `\includegraphics{...}` or text such as `\textsf{\textbf{Yritys Oy}}`. Placed top-left; the page header grows automatically to fit a tall logo. A logo taller than `\logomaxheight` (20 mm by default) is scaled down proportionally — adjust with `\setlength{\logomaxheight}{30mm}`. When no `\logo` is given, the organization name from `\contactinfo` stands in its place |
 | `\recipient{Oy Yritys Ab\\Essi Esimerkki\\Esimerkkitie 1\\12345 Esimerkkipaikkakunta}` | Vastaanottajan tietoalue | Optional; placed at the left margin below the metadata |
 | `\subject{Digiprojekti}` | Aihe | Bold line directly above the main title |
 | `\keywords{asiakaspalaute, kysely}` | — | Keywords (asiasanat) for the PDF Keywords property; not shown on the document |
 | `\title{Verkkosivujen uudistaminen}` | Pääotsikko | Bold, 3 pt larger than the body text |
-| `\contactinfo{Organisaatio Oy}{Katuosoite\\12345 Postitoimipaikka\\Puhelinnumero\\www-osoite\\Y-tunnus}` | Organisaation yhteystiedot | Stored for `\makecontactinfo`; first argument is the bolded organization name |
+| `\contactinfo{Organisaatio Oy}{Katuosoite\\12345 Postitoimipaikka\\Puhelinnumero\\www-osoite\\Y-tunnus}` | Organisaation yhteystiedot | Stored for `\makecontactinfo`; first argument is the bolded organization name (also shown top-left in place of a missing `\logo`) |
 
 The metadata is also written into the PDF document properties — title,
 subject, author (laatija from `\author`), keywords and document language

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -73,7 +73,8 @@ keywords: [palaute, kysely]          # \keywords — PDF Keywords (asiasanat),
 docid: Dnro 123/2024                 # \docid
 confidentiality: Luottamuksellinen   # \confidentiality
 logo: logo-organisaatio.pdf          # image path (pdf/eps/png/jpg/svg),
-                                     # or text such as "**Yritys Oy**"
+                                     # or text such as "**Yritys Oy**".
+                                     # Omit it to show contact.name instead
 recipient: [Oy Yritys Ab, Esimerkkitie 1, 12345 Esimerkkipaikkakunta]
 extrametadata: [Hankenumero 123456, Asiakasnumero 987654]
 contact:                             # \contactinfo + \makecontactinfo at the end

--- a/sfs-2487-2024.cls
+++ b/sfs-2487-2024.cls
@@ -205,7 +205,13 @@
 \newcommand{\sfs@pagenum}{\thepage\ (\ref*{TotPages})}
 
 \newcommand{\sfs@metadatablock}{%
-  \ifx\sfs@logo\@empty\else
+  \ifx\sfs@logo\@empty
+    % No logo: stand the organisation name in the logo's place, on the first
+    % metadata line at the left margin (5.1, organisaation tunnistetiedot).
+    \ifx\sfs@contactname\@empty\else
+      \rlap{\textbf{\sfs@contactname}}%
+    \fi
+  \else
     \rlap{\raisebox{\dimexpr\ht\strutbox-\height\relax}{\sfs@logo}}%
   \fi
   \hspace*{\sfs@metaindent}%

--- a/web/README.md
+++ b/web/README.md
@@ -132,9 +132,11 @@ uploads an image (PNG, JPEG or SVG): `src/main.ts` reads the file into a
 `$typst.mapShadow("/logo.<ext>", bytes)`, and the converter emits
 `logo: image("/logo.<ext>")` into the `sfs-document(...)` call. The template
 hangs it in the 20 mm margin and caps it at 20 mm height (scaling down only when
-taller, like the LaTeX class). **Poista logo** removes it again. SVG logos work
+taller, like the LaTeX class), and the body drops to clear a tall logo by the
+same gap the class keeps. **Poista logo** removes it again. SVG logos work
 natively — Typst decodes SVG itself, so the pandoc pipeline's `rsvg-convert`
-step is not needed.
+step is not needed. With no logo uploaded, the organisation name (`contact.name`)
+stands in its place top-left, as in the LaTeX class.
 
 ## Known gaps (out of scope for the spike)
 

--- a/web/src/sfs-2487-2024.typ
+++ b/web/src/sfs-2487-2024.typ
@@ -20,6 +20,11 @@
 #let metawidth = 88mm // 200 mm right text edge − 112 mm
 #let logo-max-height = 20mm
 #let header-top = 14.4mm // top margin above the metadata block (cls geometry top)
+#let body-top = 42mm // where the body starts (cls top + headheight + headsep)
+// Gap kept below the top area (logo or metadata block) before the body, when
+// the area is tall enough to need pushing the body down — the class grows its
+// header height to fit a tall logo/metadata and keeps \headsep below it.
+#let top-clearance = 10.5mm
 #let leading = 5.2pt // within-paragraph line gap (→ 13.2 pt baseline at 11 pt)
 #let parskip = 11.6pt // LaTeX paragraph gap (kappaleväli, .88 baselineskip)
 // Typst measures block spacing between bounding boxes, whereas LaTeX adds the
@@ -119,6 +124,15 @@
   let body-font = font-families.at(font, default: font-families.sans-serif)
   runin-state.update(runin)
 
+  // The text part of the metadata block, kept as a value so its height can be
+  // measured when deciding how far to push the body down (see below).
+  let meta-box = box(width: metawidth)[
+    #strong(doctype) #h(1fr) #context counter(page).display("1 (1)", both: true) \
+    #date
+    #if docid != none [ \ #docid ]
+    #if confidentiality != none [ \ #confidentiality ]
+  ]
+
   // The basic metadata block, repeated as the page header on every page; the
   // page number is "current (total)" — e.g. 1 (2).
   let metadata-block = {
@@ -132,18 +146,12 @@
           logo
         }
       })
+    } else if contact != none and contact.at("name", default: "") != "" {
+      // No logo: stand the organisation name in the logo's place, in the 20 mm
+      // margin aligned with the first metadata line (cls \sfs@metadatablock).
+      place(top + left, dx: -column, dy: header-top, strong(contact.name))
     }
-    place(
-      top + left,
-      dx: meta-offset,
-      dy: header-top,
-      box(width: metawidth)[
-        #strong(doctype) #h(1fr) #context counter(page).display("1 (1)", both: true) \
-        #date
-        #if docid != none [ \ #docid ]
-        #if confidentiality != none [ \ #confidentiality ]
-      ],
-    )
+    place(top + left, dx: meta-offset, dy: header-top, meta-box)
   }
 
   set document(
@@ -157,10 +165,10 @@
     height: 297mm,
     // top: leaves room for the 14.4 mm top margin, the metadata block and a
     // headsep gap so the body starts where the class puts it (~42 mm).
-    margin: (left: body-indent, right: 10mm, top: 42mm, bottom: 20mm),
+    margin: (left: body-indent, right: 10mm, top: body-top, bottom: 20mm),
     // The metadata block is placed absolutely from the page top (header-top),
     // so the header region spans the whole top margin to contain it.
-    header-ascent: 42mm,
+    header-ascent: body-top,
     header: metadata-block,
   )
   set text(font: body-font, size: fontsize, lang: "fi", hyphenate: true)
@@ -202,20 +210,34 @@
   show figure.where(kind: table): set figure.caption(position: top)
   show figure.caption: set text(hyphenate: false)
 
+  // Push the body down when the top area (a tall logo, or a many-line metadata
+  // block) would otherwise crowd it. The class grows its header height to fit
+  // the logo/metadata and keeps \headsep below it, so the body drops; here the
+  // body start is fixed at body-top, so reserve the shortfall explicitly. Short
+  // metadata adds nothing — the body stays where it already matches the class.
+  context {
+    let meta-h = measure(meta-box).height
+    let logo-h = if logo != none { calc.min(measure(logo).height, logo-max-height) } else { 0pt }
+    let delta = header-top + calc.max(meta-h, logo-h) + top-clearance - body-top
+    if delta > 0pt { v(delta, weak: false) }
+  }
+
   // Body text sits at the 43 mm column (the page's left margin). Margin-hanging
   // elements (headings, marginlabels) outdent by `column`; the extra metadata
   // area is offset to the 112 mm column.
   if extrametadata != none {
     block(pad(left: meta-offset, extrametadata))
   }
-  if recipient != none { block(recipient) }
+  if recipient != none { block(pad(left: -column, recipient)) }
   // Subject and title share one block with the title leading between them, as
   // the class typesets them in a single parbox (5.2); the title is the
-  // document's level-1 heading, bold and 3 pt larger (5.2.1).
-  block(below: 1.5 * parskip, {
+  // document's level-1 heading, bold and 3 pt larger (5.2.1). Like the other
+  // information areas they hang at the 20 mm margin (cls \maketitle outdents
+  // the recipient and title parboxes by \sfs@column), not the body indent.
+  block(below: 1.5 * parskip, pad(left: -column, {
     if subject != none { strong(subject); linebreak() }
     text(size: fontsize + 3pt, weight: "bold", hyphenate: false, title)
-  })
+  }))
 
   if toc {
     // The TOC heading stays on a line of its own (cls \tableofcontents,


### PR DESCRIPTION
## Summary

Three layout fixes, verified against the LaTeX class with `pdftotext -bbox`. The first two are typst-only (the browser editor); the third is a class feature applied to every rendering path.

### 1. Subject / title (and recipient) indent — typst

The subject, title and recipient sat at the 43 mm body column, but the class outdents them to the 20 mm margin (`\maketitle` hangs the recipient and title parboxes by `\sfs@column`). They now hang there too.

- **Measured:** subject "Digiprojekti" and title at **56.69 pt (20 mm)**, matching the class (was 121.9 pt / 43 mm).

### 2. Top-area-to-content margin — typst

When the top area is tall (a 20 mm logo, or a many-line metadata block) the body crowded it: the body start was fixed at 42 mm while the class grows its header height to fit the logo/metadata and keeps `\headsep` below. The body now drops by the shortfall, reserved from a measurement of the logo/metadata height.

- **Measured (20 mm logo):** content at **44.7 mm** (class 45.2 mm), gap below the logo **~10.3 mm** vs the class's 10.1 mm.
- **No-logo / short metadata:** body position **unchanged** (still matches the class), so no regression on the existing examples.

### 3. No logo → organisation name — all versions

When no logo is given, the organisation name (`\contactinfo` / `contact.name`) stands in the logo's place, top-left on the first metadata line.

- Added to the class (`\sfs@metadatablock`) and the typst template. The pandoc front end already passes the contact name, so no change there.
- **Measured (LaTeX, no logo):** "Organisaatio Oy" at **56.69 pt**, on the first metadata line.
- The browser editor, which cannot read the example logo paths, now shows the org name instead of an empty corner.
- Documented in `docs/latex.md`, `docs/markdown.md` and `web/README.md`.

All six committed examples carry a logo, so their LaTeX/pandoc output is unchanged (the class change only touches the no-logo branch); the fallback is verified via ad-hoc no-logo builds and the browser editor.

## Verification

`make examples` and `make markdown` (flake-pinned TeX Live) build cleanly; the browser bundle builds and renders via the headless smoke test. typst positions were measured from the in-browser PDF, the LaTeX positions from the class examples and ad-hoc 20 mm-logo / no-logo builds.

https://claude.ai/code/session_01PdiwSqT6wbs2zDoUsfD4M1

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdiwSqT6wbs2zDoUsfD4M1)_