### PR TITLE
web: make the editor usable on mobile with a responsive single-pane layout

### DIFF
--- a/docs/web-editor.md
+++ b/docs/web-editor.md
@@ -151,7 +151,10 @@ Either route uses the same front end: [CodeMirror 6](https://codemirror.net)
 preview rendered either by [pdf.js](https://mozilla.github.io/pdf.js/)
 or, for Route 2, by typst.ts's own SVG renderer. Prior art to study
 includes [pandoc.org/app](https://pandoc.org/app) (pandoc-WebAssembly in
-the browser) and the various typst.ts editor demos.
+the browser) and the various typst.ts editor demos. The split pane is
+responsive: on a phone-sized screen the two panes collapse to a single
+column with a Muokkaa / Esikatselu switch choosing which one is shown,
+since a half-width editor and preview are unusable side by side there.
 
 ## Prototype plan to decide between the routes
 

--- a/web/README.md
+++ b/web/README.md
@@ -73,6 +73,14 @@ short line that a long error can never reflow):
 - Conversion and compile **errors appear as dismissible toasts at the bottom
   right**; the status bar itself only ever shows the short compile state
   (`käännetty`, `virhe`, …), so it never grows or reflows.
+- The layout is **responsive**: on wide screens the editor and preview sit side
+  by side, but on narrow (mobile) screens — at a 700 px breakpoint — they would
+  be too cramped, so they collapse to a single column showing one pane at a
+  time. A **Muokkaa / Esikatselu** switch in the top bar (shown only on mobile)
+  chooses which. The status bar wraps its controls instead of overflowing, the
+  height tracks the dynamic viewport (`100dvh`) so the bar is not hidden behind
+  mobile browser chrome, and the editor uses 16 px text to stop iOS Safari from
+  zooming on focus.
 
 ## Preview controls
 
@@ -127,8 +135,11 @@ pdftotext -bbox /tmp/dl/* -
 A companion `scripts/verify-ui.mjs` (same Chromium + `puppeteer-core` setup)
 checks the editor chrome rather than the layout: that the controls live in the
 bottom status bar, the Vim mode badge tracks `NORMAL` → `VISUAL`, the
-visual-mode selection is painted in a visible colour, and a conversion error
-surfaces as a bottom-right toast without reflowing the header.
+visual-mode selection is painted in a visible colour, a conversion error
+surfaces as a bottom-right toast without reflowing the header, and the
+responsive layout works — at a phone viewport the panes collapse to one column
+with the Muokkaa / Esikatselu switch toggling which is visible and no horizontal
+overflow, while a wide viewport shows both panes with the switch hidden.
 
 That smoke test caught one real issue the CLI could not: by default typst.ts
 fetches its built-in fonts from a CDN (jsdelivr), which breaks offline /

--- a/web/index.html
+++ b/web/index.html
@@ -5,9 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>SFS 2487:2024 – selaineditori (prototyyppi)</title>
   </head>
-  <body>
+  <body class="show-editor">
     <header>
-      <strong>SFS 2487:2024</strong> – Markdown → PDF (typst.ts-prototyyppi)
+      <span class="brand"><strong>SFS 2487:2024</strong>
+        <span class="brand-sub">– Markdown → PDF (typst.ts-prototyyppi)</span></span>
+      <!-- Single-pane view switch, shown only on narrow (mobile) screens where
+           the two panes cannot sit side by side; hidden on wide screens. -->
+      <div id="view-toggle" class="view-toggle" role="tablist" aria-label="Näkymä">
+        <button id="show-editor" type="button" role="tab" aria-selected="true">Muokkaa</button>
+        <button id="show-preview" type="button" role="tab" aria-selected="false">Esikatselu</button>
+      </div>
     </header>
     <main>
       <div id="editor" aria-label="Markdown"></div>

--- a/web/scripts/verify-ui.mjs
+++ b/web/scripts/verify-ui.mjs
@@ -95,5 +95,35 @@ const status = await page.$eval("#status", (e) => e.textContent);
 console.log("TOAST:", JSON.stringify(toast));
 console.log("STATUS_AFTER_ERROR:", status);
 console.log("HEADER_HEIGHT_STABLE:", headerBefore === headerAfter, headerBefore, headerAfter);
+
+// Mobile layout: at a phone viewport the two panes collapse to one column with
+// the Editor/Preview switch deciding which pane is visible, and nothing should
+// overflow the viewport width. At a wide viewport both panes show and the
+// switch is hidden.
+const visible = (sel) =>
+  page.$eval(sel, (e) => getComputedStyle(e).display !== "none" && e.offsetParent !== null);
+const noHScroll = () =>
+  page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1);
+
+await page.setViewport({ width: 390, height: 780 }); // iPhone-ish portrait
+await new Promise((r) => setTimeout(r, 150));
+const toggleShown = await visible("#view-toggle");
+const mobileDefault = { editor: await visible("#editor"), preview: await visible("#preview") };
+await page.click("#show-preview");
+const mobilePreview = { editor: await visible("#editor"), preview: await visible("#preview") };
+await page.click("#show-editor");
+const mobileEditor = { editor: await visible("#editor"), preview: await visible("#preview") };
+const mobileNoHScroll = await noHScroll();
+console.log("MOBILE_TOGGLE_SHOWN:", toggleShown);
+console.log("MOBILE_DEFAULT (editor only):", JSON.stringify(mobileDefault));
+console.log("MOBILE_PREVIEW (preview only):", JSON.stringify(mobilePreview));
+console.log("MOBILE_EDITOR (editor only):", JSON.stringify(mobileEditor));
+console.log("MOBILE_NO_HSCROLL:", mobileNoHScroll);
+
+await page.setViewport({ width: 1200, height: 800 }); // desktop
+await new Promise((r) => setTimeout(r, 150));
+const wide = { toggle: await visible("#view-toggle"), editor: await visible("#editor"), preview: await visible("#preview") };
+console.log("WIDE (toggle hidden, both panes):", JSON.stringify(wide));
+
 await browser.close();
 server.close();

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -60,6 +60,8 @@ const zoomLevelEl = document.getElementById("zoom-level")!;
 const fitWidthEl = document.getElementById("fit-width") as HTMLButtonElement;
 const fitHeightEl = document.getElementById("fit-height") as HTMLButtonElement;
 const twoUpEl = document.getElementById("two-up") as HTMLButtonElement;
+const showEditorEl = document.getElementById("show-editor") as HTMLButtonElement;
+const showPreviewEl = document.getElementById("show-preview") as HTMLButtonElement;
 
 function setStatus(text: string, error = false) {
   statusEl.textContent = text;
@@ -388,6 +390,22 @@ vimEl.addEventListener("change", () => {
 });
 
 syncVimMode();
+
+// Editor/Preview pane switch (visible only on narrow screens via CSS, where the
+// two panes cannot sit side by side). The body class drives which pane shows;
+// on wide screens it is inert because the media query keeps both panes visible.
+// (The preview's fit-to-width recomputes itself: showing the pane resizes it
+// from zero width, which the previewEl ResizeObserver picks up.)
+function showPane(pane: "editor" | "preview") {
+  document.body.classList.toggle("show-editor", pane === "editor");
+  document.body.classList.toggle("show-preview", pane === "preview");
+  showEditorEl.setAttribute("aria-selected", String(pane === "editor"));
+  showPreviewEl.setAttribute("aria-selected", String(pane === "preview"));
+  if (pane === "editor") editor.focus();
+}
+
+showEditorEl.addEventListener("click", () => showPane("editor"));
+showPreviewEl.addEventListener("click", () => showPane("preview"));
 
 // Start over from the seeded example: reset the document and logo (and their
 // saved copies), but keep the Vim toggle — it is an editor preference, not part

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -5,17 +5,25 @@
 html,
 body {
   margin: 0;
-  height: 100%;
   font-family: system-ui, sans-serif;
+}
+
+html {
+  height: 100%;
 }
 
 body {
   display: flex;
   flex-direction: column;
+  /* 100dvh tracks the *dynamic* viewport so the bottom status bar is not hidden
+     behind a mobile browser's address/tool bars; height:100% is the fallback. */
+  height: 100%;
+  height: 100dvh;
 }
 
-/* The top bar carries only the title now — the controls live in the bottom
-   status bar, so a long error message can no longer reflow it. */
+/* The top bar carries the title and (on mobile) the view switch — the editing
+   controls live in the bottom status bar, so a long error message can no
+   longer reflow it. */
 header {
   display: flex;
   gap: 1rem;
@@ -24,6 +32,40 @@ header {
   background: #37474f;
   color: #fff;
   flex: 0 0 auto;
+}
+
+.brand {
+  white-space: nowrap;
+}
+
+/* The Editor/Preview switch: a segmented control pushed to the right of the
+   header. Hidden on wide screens, where both panes show side by side. */
+.view-toggle {
+  display: none;
+  margin-left: auto;
+}
+
+.view-toggle button {
+  appearance: none;
+  border: 1px solid #607d8b;
+  background: transparent;
+  color: #fff;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.view-toggle button:first-child {
+  border-radius: 0.3rem 0 0 0.3rem;
+  border-right: none;
+}
+
+.view-toggle button:last-child {
+  border-radius: 0 0.3rem 0.3rem 0;
+}
+
+.view-toggle button[aria-selected="true"] {
+  background: #607d8b;
 }
 
 main {
@@ -228,4 +270,62 @@ main {
 .toast.leaving {
   opacity: 0;
   transform: translateX(1rem);
+}
+
+/* --- Mobile / narrow screens --- */
+/* Two half-width panes are unusable on a phone, so collapse to a single column
+   and show one pane at a time, switched by the header's Editor/Preview control.
+   The status bar is allowed to wrap so its controls never overflow off-screen. */
+@media (max-width: 700px) {
+  .brand-sub {
+    display: none; /* keep the header to one short line */
+  }
+
+  .view-toggle {
+    display: inline-flex;
+  }
+
+  main {
+    grid-template-columns: 1fr; /* single column; one pane visible at a time */
+  }
+
+  /* The draggable divider is meaningless with one pane visible. */
+  #divider {
+    display: none;
+  }
+
+  body.show-editor #preview-pane,
+  body.show-preview #editor {
+    display: none;
+  }
+
+  /* 16px text stops iOS Safari from auto-zooming when the editor gains focus. */
+  #editor .cm-editor {
+    font-size: 16px;
+  }
+
+  /* The preview toolbar has several buttons; let them wrap instead of overflow. */
+  #preview-toolbar {
+    flex-wrap: wrap;
+  }
+
+  #statusbar {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  #statusbar .bar-left,
+  #statusbar .bar-right {
+    flex-wrap: wrap;
+  }
+
+  /* Roomier tap targets for touch. */
+  #statusbar button,
+  .view-toggle button {
+    min-height: 2.4rem;
+  }
+
+  #logo-label input {
+    max-width: 12ch;
+  }
 }


### PR DESCRIPTION
The two-column editor/preview split is unusable on a phone: each pane gets
half of an already narrow screen. On screens at or below 700 px the panes now
collapse to a single column showing one at a time, switched by a Muokkaa /
Esikatselu control in the top bar (hidden on wide screens). The status bar
wraps its controls instead of overflowing, the body height tracks the dynamic
viewport (100dvh) so the bar is not hidden behind mobile browser chrome, the
editor uses 16 px text to stop iOS Safari from zooming on focus, and tap
targets are roomier.

verify-ui.mjs gains a mobile-layout check (single pane, working switch, no
horizontal overflow; both panes and hidden switch on a wide viewport).

https://claude.ai/code/session_01H9VeSL4TjQisif1jrYPicH