### PR TITLE
web: keyboard-gated Vim and floating preview controls

### DIFF
--- a/docs/web-editor.md
+++ b/docs/web-editor.md
@@ -161,6 +161,10 @@ the top header is dropped so a single bottom bar is the only chrome, for
 an app-like feel. All controls are SVG icon buttons with accessible
 names, visible focus rings and 44 px touch targets; errors surface as
 `role="alert"` toasts that are dismissable by mouse, keyboard or Escape.
+The Vim toggle is keyboard-gated — hidden on phones and shown only when a
+physical keyboard is likely (a mouse/trackpad via `(hover: hover) and
+(pointer: fine)`, or a hardware keystroke detected at runtime, since no web
+API reports keyboard presence).
 The editor is also an installable **PWA** — a web app manifest plus a
 cache-first service worker let it be added to the home screen and
 launched standalone (no browser chrome) and used offline, which fits a

--- a/docs/web-editor.md
+++ b/docs/web-editor.md
@@ -159,8 +159,11 @@ a single column with a Muokkaa / Esikatselu switch choosing which one is
 shown (a half-width editor and preview are unusable side by side there);
 the top header is dropped so a single bottom bar is the only chrome, for
 an app-like feel. All controls are SVG icon buttons with accessible
-names, visible focus rings and 44 px touch targets; errors surface as
-`role="alert"` toasts that are dismissable by mouse, keyboard or Escape.
+names, visible focus rings and 44 px touch targets; the preview's zoom
+and fit controls live in a floating pill at its bottom-right that fades
+in on hover/focus/activity and out when idle, rather than a fixed
+toolbar. Errors surface as `role="alert"` toasts that are dismissable by
+mouse, keyboard or Escape.
 The Vim toggle is keyboard-gated — hidden on phones and shown only when a
 physical keyboard is likely (a mouse/trackpad via `(hover: hover) and
 (pointer: fine)`, or a hardware keystroke detected at runtime, since no web

--- a/web/README.md
+++ b/web/README.md
@@ -58,14 +58,17 @@ buttons** — each carries an `aria-label` and a `title` tooltip, renders an SVG
 from an inline `<symbol>` sprite, has a visible `:focus-visible` ring, and is at
 least a 44 px touch target on mobile:
 
-- **Vim** (bottom left, desktop only) — a checkbox toggling Vim keybindings
+- **Vim** (bottom left) — a checkbox toggling Vim keybindings
   ([@replit/codemirror-vim](https://github.com/replit/codemirror-vim)) in the
   CodeMirror editor, switched live via a `Compartment`. When Vim is on, a badge
   next to it shows the current mode (`NORMAL` / `INSERT` / `VISUAL` …), driven by
   the extension's `vim-mode-change` event. The editor enables CodeMirror's
   `drawSelection()` — which the Vim extension needs to paint the visual-mode
   selection — and themes the painted selection a clearly visible blue so
-  selected text stands out, focused or not.
+  selected text stands out, focused or not. **Vim only makes sense with a
+  physical keyboard**, so the control is hidden unless one is likely (see
+  _Keyboard detection_ below) — and it is not applied without one, so an
+  on-screen keyboard is never trapped in Vim's normal mode.
 - **Logo / Poista logo / Uusi esimerkki / Lataa PDF** (bottom right) — logo
   upload (a styled file input), document/logo reset back to the seeded example
   (the Vim toggle is kept — it is an editor preference), and PDF download.
@@ -93,10 +96,27 @@ layout collapses to a single column showing one pane at a time:
   toggle buttons) is the primary navigation. Following the native bottom-bar
   idiom, only the *selected* tab shows its text label; the other is icon-only,
   which keeps both tabs and the action icons on one row without overflow.
-- Vim is hidden (a desktop power feature), the height tracks the dynamic
-  viewport (`100dvh`), the bar respects the safe-area insets (so it clears a
-  notched phone's home indicator), and the editor uses 16 px text to stop iOS
-  Safari from zooming on focus.
+- Vim is hidden unless a keyboard is detected (see below), the height tracks
+  the dynamic viewport (`100dvh`), the bar respects the safe-area insets (so it
+  clears a notched phone's home indicator), and the editor uses 16 px text to
+  stop iOS Safari from zooming on focus.
+
+### Keyboard detection
+
+There is **no web API for hardware-keyboard presence** (`navigator.keyboard`
+only exposes layout maps; the VirtualKeyboard API is about the on-screen
+keyboard), so the Vim gate uses two complementary signals:
+
+- **CSS** `@media (hover: hover) and (pointer: fine)` — a precise pointer with
+  hover means a mouse/trackpad, which implies a keyboard setup (desktops,
+  laptops, an iPad with a trackpad keyboard). This reveals the control with no
+  flash and no JavaScript.
+- A **runtime heuristic** (`src/main.ts`): a `keydown` for a key an on-screen
+  keyboard rarely emits — Tab, Escape, an arrow, a function key, or a
+  Ctrl/Alt/Meta combo — adds `body.keyboard` and enables Vim. This catches the
+  case the media query misses: a tablet with a Bluetooth keyboard, which
+  iPadOS Safari still reports as a coarse/no-hover touch device
+  ([WebKit #209292](https://bugs.webkit.org/show_bug.cgi?id=209292)).
 
 ### Install as an app (PWA)
 
@@ -161,9 +181,11 @@ pdftotext -bbox /tmp/dl/* -
 ```
 
 A companion `scripts/verify-ui.mjs` (same Chromium + `puppeteer-core` setup)
-checks the editor chrome rather than the layout: that the controls live in the
-bottom status bar, the Vim mode badge tracks `NORMAL` → `VISUAL`, the
-visual-mode selection is painted in a visible colour, and a conversion error
+checks the editor chrome rather than the layout (it runs as an emulated touch
+device): that the controls live in the bottom status bar, the keyboard-gated Vim
+control is hidden with no keyboard and appears once a hardware keystroke is
+detected, the Vim mode badge then tracks `NORMAL` → `VISUAL`, the visual-mode
+selection is painted in a visible colour, and a conversion error
 surfaces as a bottom-right `role="alert"` toast (with a working close button,
 dismissed afterwards) without reflowing the header. It also checks the
 accessibility and PWA work added here: every icon button has an accessible name

--- a/web/README.md
+++ b/web/README.md
@@ -72,8 +72,11 @@ least a 44 px touch target on mobile:
 - **Logo / Poista logo / Uusi esimerkki / Lataa PDF** (bottom right) — logo
   upload (a styled file input), document/logo reset back to the seeded example
   (the Vim toggle is kept — it is an editor preference), and PDF download.
-- **Preview toolbar** (above the preview) — zoom out / in, fit to width, fit to
-  height, and a one-/two-page toggle (`aria-pressed`), all as icons.
+- **Preview controls** — zoom out / in, fit to width, fit to height, and a
+  one-/two-page toggle (`aria-pressed`), all as icons, in a **floating pill at
+  the bottom-right of the preview**. It fades in on hover or focus, or briefly on
+  activity (scroll/touch — essential where there is no hover), and fades out when
+  idle, so it never steals space from the preview.
 - The document, the uploaded logo and the Vim toggle are autosaved to the
   browser's `localStorage` and restored on reload. (A restored logo cannot
   repopulate the file input, so the **Poista logo** button — with the file name
@@ -182,7 +185,7 @@ pdftotext -bbox /tmp/dl/* -
 
 A companion `scripts/verify-ui.mjs` (same Chromium + `puppeteer-core` setup)
 checks the editor chrome rather than the layout (it runs as an emulated touch
-device): that the controls live in the bottom status bar, the keyboard-gated Vim
+device): that the bottom-bar buttons are vertically centred, the keyboard-gated Vim
 control is hidden with no keyboard and appears once a hardware keystroke is
 detected, the Vim mode badge then tracks `NORMAL` → `VISUAL`, the visual-mode
 selection is painted in a visible colour, and a conversion error

--- a/web/index.html
+++ b/web/index.html
@@ -68,7 +68,10 @@
       <div id="divider" role="separator" aria-orientation="vertical" aria-label="Siirrä jakajaa"
         tabindex="0" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50"></div>
       <section id="preview-pane" aria-label="Esikatselu">
-        <div id="preview-toolbar" role="toolbar" aria-label="Esikatselun hallinta">
+        <div id="preview" aria-label="Esikatselu" aria-busy="false"><div id="pages"></div></div>
+        <!-- Floating controls over the bottom-right of the preview; they fade in
+             on hover/focus/activity and fade out otherwise (see main.ts). -->
+        <div id="preview-controls" role="toolbar" aria-label="Esikatselun hallinta">
           <button id="zoom-out" type="button" class="iconbtn" title="Loitonna" aria-label="Loitonna">
             <svg class="icon" aria-hidden="true" focusable="false"><use href="#i-zoom-out" /></svg>
           </button>
@@ -87,7 +90,6 @@
             <svg class="icon" aria-hidden="true" focusable="false"><use href="#i-spread" /></svg>
           </button>
         </div>
-        <div id="preview" aria-label="Esikatselu" aria-busy="false"><div id="pages"></div></div>
       </section>
     </main>
     <footer id="statusbar">

--- a/web/scripts/verify-ui.mjs
+++ b/web/scripts/verify-ui.mjs
@@ -182,6 +182,20 @@ const visible = (sel) =>
   page.$eval(sel, (e) => getComputedStyle(e).display !== "none" && e.offsetParent !== null);
 const noHScroll = () =>
   page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1);
+// Largest gap between any visible bottom-bar control's centre and the bar's
+// centre — should be ~0 if the buttons are vertically centred.
+const barCenterOffset = () =>
+  page.evaluate(() => {
+    const bar = document.getElementById("statusbar").getBoundingClientRect();
+    const mid = bar.top + bar.height / 2;
+    const ctrls = [...document.querySelectorAll("#statusbar .iconbtn, #statusbar .view-toggle button")]
+      .filter((e) => e.offsetParent !== null);
+    return Math.max(0, ...ctrls.map((e) => {
+      const r = e.getBoundingClientRect();
+      return Math.abs(r.top + r.height / 2 - mid);
+    }));
+  });
+console.log("DESKTOP_BOTTOMBAR_CENTER_OFFSET_PX:", (await barCenterOffset()).toFixed(2));
 
 await page.setViewport({ width: 390, height: 780 }); // iPhone-ish portrait
 await new Promise((r) => setTimeout(r, 150));
@@ -198,6 +212,7 @@ console.log("MOBILE_DEFAULT (editor only):", JSON.stringify(mobileDefault));
 console.log("MOBILE_PREVIEW (preview only):", JSON.stringify(mobilePreview));
 console.log("MOBILE_EDITOR (editor only):", JSON.stringify(mobileEditor));
 console.log("MOBILE_NO_HSCROLL:", mobileNoHScroll);
+console.log("MOBILE_BOTTOMBAR_CENTER_OFFSET_PX:", (await barCenterOffset()).toFixed(2));
 
 await page.setViewport({ width: 1200, height: 800 }); // desktop
 await new Promise((r) => setTimeout(r, 150));

--- a/web/scripts/verify-ui.mjs
+++ b/web/scripts/verify-ui.mjs
@@ -32,11 +32,28 @@ const browser = await puppeteer.launch({
 const page = await browser.newPage();
 page.on("pageerror", (e) => console.error("PAGEERROR:", e.message));
 page.on("console", (m) => m.type() === "error" && console.error("CONSOLE:", m.text()));
+
+// Run the whole session as a touch device (coarse pointer, no hover) so the
+// Vim keyboard gate can be checked without a reload. puppeteer-core's
+// emulateMediaFeatures has a fixed whitelist excluding hover/pointer, so go
+// through CDP directly.
+const cdp = await page.target().createCDPSession();
+await cdp.send("Emulation.setEmulatedMedia", {
+  features: [
+    { name: "hover", value: "none" },
+    { name: "pointer", value: "coarse" },
+  ],
+});
+
 await page.goto(`http://localhost:${port}/`, { waitUntil: "load" });
 await page.waitForFunction(
   () => document.getElementById("status")?.textContent === "käännetty",
   { timeout: 120000 },
 );
+
+// Vim is keyboard-gated: on a touch device with no keyboard the control starts
+// hidden (it is revealed below once a hardware keystroke is detected).
+console.log("VIM_HIDDEN_NO_KEYBOARD:", await page.$eval("#vim-label", (e) => e.offsetParent === null));
 
 // Controls now live in the bottom status bar.
 const inBar = await page.$$eval("#statusbar button, #statusbar #vim-mode, #statusbar #vim",
@@ -59,6 +76,15 @@ async function dragSelectFirstLine() {
 await dragSelectFirstLine();
 const plainSel = await page.$$eval(".cm-selectionBackground", (els) => els.map((e) => getComputedStyle(e).backgroundColor));
 console.log("PLAIN_SELECTION_BACKGROUNDS:", JSON.stringify(plainSel));
+
+// Vim is keyboard-gated. Simulate a hardware keystroke (a bare Control press,
+// which an on-screen keyboard does not produce) to reveal the control — headless
+// Chromium may report a coarse pointer, which keeps it hidden otherwise.
+await page.click(".cm-content");
+await page.keyboard.down("Control");
+await page.keyboard.up("Control");
+await page.waitForSelector("#vim-label", { visible: true });
+console.log("VIM_SHOWN_AFTER_KEY:", await page.$eval("#vim-label", (e) => e.offsetParent !== null));
 
 // Enable Vim and check the mode badge appears as NORMAL.
 await page.click("#vim");

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -349,8 +349,17 @@ logoClearEl.addEventListener("click", async () => {
 // without rebuilding the editor. The vim() extension must come first, before the
 // other keymaps, for its bindings to take precedence.
 const vimCompartment = new Compartment();
-const vimEnabled = lsGet(STORE.vim) === "1";
-vimEl.checked = vimEnabled;
+const vimWanted = lsGet(STORE.vim) === "1";
+vimEl.checked = vimWanted;
+
+// Vim only makes sense with a physical keyboard, so it is gated on the same
+// signals the CSS uses to reveal the control: a precise pointer + hover
+// (mouse/trackpad, which implies a keyboard), or real keyboard input detected
+// at runtime. There is no web API for hardware-keyboard presence, so this is a
+// pragmatic best effort — see onKeyboard() below for the runtime heuristic.
+const kbMedia = window.matchMedia("(hover: hover) and (pointer: fine)");
+let keyboardPresent = kbMedia.matches;
+if (keyboardPresent) document.body.classList.add("keyboard");
 
 // In Vim mode the @replit/codemirror-vim theme forces the browser's native
 // ::selection transparent and relies on drawSelection() to paint the visual
@@ -371,7 +380,7 @@ const editor = new EditorView({
   parent: document.getElementById("editor")!,
   doc: lsGet(STORE.doc) ?? withoutLogo(seed),
   extensions: [
-    vimCompartment.of(vimEnabled ? vim() : []),
+    vimCompartment.of(vimWanted && keyboardPresent ? vim() : []),
     lineNumbers(),
     history(),
     drawSelection(),
@@ -409,7 +418,7 @@ function showVimMode(mode: string, sub?: string) {
 }
 
 function syncVimMode() {
-  if (!vimEl.checked) {
+  if (!vimEl.checked || !keyboardPresent) {
     vimModeEl.hidden = true;
     return;
   }
@@ -425,12 +434,45 @@ function syncVimMode() {
   );
 }
 
-vimEl.addEventListener("change", () => {
-  editor.dispatch({ effects: vimCompartment.reconfigure(vimEl.checked ? vim() : []) });
-  lsSet(STORE.vim, vimEl.checked ? "1" : "0");
+// Apply Vim only when the user wants it AND a keyboard is present; the
+// preference is persisted regardless, so it takes effect once a keyboard
+// appears (a touch device kept in Vim's normal mode would otherwise trap the
+// on-screen keyboard).
+function applyVim() {
+  const on = vimEl.checked && keyboardPresent;
+  editor.dispatch({ effects: vimCompartment.reconfigure(on ? vim() : []) });
   syncVimMode();
+}
+
+vimEl.addEventListener("change", () => {
+  lsSet(STORE.vim, vimEl.checked ? "1" : "0");
+  applyVim();
   editor.focus();
 });
+
+// Reveal and enable Vim once a keyboard is detected — covers a tablet with a
+// keyboard but a coarse pointer, which the media query above misses (e.g. an
+// iPad with a Bluetooth keyboard). Keys an on-screen keyboard rarely emits are
+// a strong hardware-keyboard signal.
+function onKeyboard() {
+  if (keyboardPresent) return;
+  keyboardPresent = true;
+  document.body.classList.add("keyboard");
+  applyVim();
+}
+kbMedia.addEventListener?.("change", (e) => e.matches && onKeyboard());
+window.addEventListener(
+  "keydown",
+  (e) => {
+    if (
+      e.key === "Tab" || e.key === "Escape" || e.altKey || e.ctrlKey || e.metaKey ||
+      e.key.startsWith("Arrow") || /^F\d{1,2}$/.test(e.key)
+    ) {
+      onKeyboard();
+    }
+  },
+  true,
+);
 
 syncVimMode();
 

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -44,6 +44,7 @@ $typst.setRendererInitOptions({ getModule: () => rendererWasmUrl });
 const statusEl = document.getElementById("status")!;
 const downloadEl = document.getElementById("download") as HTMLButtonElement;
 const previewEl = document.getElementById("preview")!;
+const previewControlsEl = document.getElementById("preview-controls")!;
 const pagesEl = document.getElementById("pages")!;
 const logoEl = document.getElementById("logo") as HTMLInputElement;
 const logoClearEl = document.getElementById("logo-clear") as HTMLButtonElement;
@@ -487,6 +488,7 @@ function showPane(pane: "editor" | "preview") {
   showEditorEl.setAttribute("aria-pressed", String(pane === "editor"));
   showPreviewEl.setAttribute("aria-pressed", String(pane === "preview"));
   if (pane === "editor") editor.focus();
+  else flashControls(); // hint that the floating controls exist
 }
 
 showEditorEl.addEventListener("click", () => showPane("editor"));
@@ -571,6 +573,19 @@ zoomOutEl.addEventListener("click", () => setZoom(currentZoom() / ZOOM_STEP));
 fitWidthEl.addEventListener("click", () => { view.fit = "width"; saveView(); applyView(); });
 fitHeightEl.addEventListener("click", () => { view.fit = "height"; saveView(); applyView(); });
 twoUpEl.addEventListener("click", () => { view.twoUp = !view.twoUp; saveView(); applyView(); });
+
+// The floating preview controls fade out when idle. Hover and focus keep them
+// up via CSS; this surfaces them on activity (essential on touch, where there
+// is no hover) and hides them again after a short pause.
+let controlsTimer: number | undefined;
+function flashControls() {
+  previewControlsEl.classList.add("show");
+  window.clearTimeout(controlsTimer);
+  controlsTimer = window.setTimeout(() => previewControlsEl.classList.remove("show"), 2200);
+}
+for (const ev of ["pointerdown", "pointermove", "scroll", "touchstart"]) {
+  previewEl.addEventListener(ev, flashControls, { passive: true });
+}
 
 // Re-fit when the pane changes size (window resize, divider drag) in a fit mode.
 new ResizeObserver(() => { if (view.fit !== "none") applyView(); }).observe(previewEl);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -175,31 +175,46 @@ main {
 }
 
 #preview-pane {
+  position: relative; /* anchors the floating #preview-controls */
   display: flex;
   flex-direction: column;
   min-width: 0;
   min-height: 0;
 }
 
-#preview-toolbar {
-  flex: 0 0 auto;
+/* Floating preview controls: a translucent pill at the bottom-right of the
+   preview, hidden until the preview is hovered, the controls are focused, or
+   there has been recent activity (the .show class, set in main.ts). */
+#preview-controls {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  z-index: 5;
   display: flex;
   align-items: center;
-  gap: 0.3rem;
-  padding: 0.3rem 0.6rem;
-  background: #455a64;
+  gap: 0.15rem;
+  padding: 0.2rem 0.35rem;
+  background: rgba(38, 50, 56, 0.92);
   color: #fff;
   font-size: 0.85rem;
+  border-radius: 0.6rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
   user-select: none;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+#preview-pane:hover #preview-controls,
+#preview-controls:focus-within,
+#preview-controls.show {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 #zoom-level {
   min-width: 4.5ch;
   text-align: center;
-}
-
-#two-up {
-  margin-left: 0.3rem;
 }
 
 /* The preview area; a centred spinner shows while a compile is in flight. */
@@ -414,7 +429,8 @@ body.keyboard #vim-mode:not([hidden]) {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .toast {
+  .toast,
+  #preview-controls {
     transition: none;
   }
   #preview[aria-busy="true"]::after {
@@ -487,7 +503,7 @@ body.keyboard #vim-mode:not([hidden]) {
     min-height: 2.75rem;
   }
 
-  #preview-toolbar .iconbtn {
+  #preview-controls .iconbtn {
     min-height: 2.5rem;
   }
 }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -275,16 +275,35 @@ main {
   gap: 0.5rem;
 }
 
+/* Vim only makes sense with a physical keyboard, so the control is hidden by
+   default and revealed only when one is likely: a device with a precise pointer
+   and hover (a mouse/trackpad, which implies a keyboard) via the media query
+   below, or once real keyboard input is detected at runtime (body.keyboard, set
+   in main.ts — this also catches an iPad with a Bluetooth keyboard, which Safari
+   still reports as a coarse/no-hover touch device). This keeps Vim off phones
+   while keeping it on desktops and keyboard-equipped tablets. */
 #vim-label {
-  display: inline-flex;
+  display: none;
   align-items: center;
   gap: 0.35rem;
   cursor: pointer;
   user-select: none;
 }
 
-/* The current Vim mode, shown as a coloured badge only while Vim is on. */
+@media (hover: hover) and (pointer: fine) {
+  #vim-label {
+    display: inline-flex;
+  }
+}
+
+body.keyboard #vim-label {
+  display: inline-flex;
+}
+
+/* The current Vim mode, shown as a coloured badge only while Vim is on (and a
+   keyboard is present, so it never appears on a phone). */
 #vim-mode {
+  display: none;
   font-weight: 700;
   font-size: 0.75rem;
   letter-spacing: 0.05em;
@@ -304,6 +323,18 @@ main {
 
 #vim-mode[data-mode="replace"] {
   background: #c62828;
+}
+
+/* Reveal the badge (when Vim is active, i.e. not [hidden]) only where the Vim
+   control itself is shown — mirrors the #vim-label rules above. */
+@media (hover: hover) and (pointer: fine) {
+  #vim-mode:not([hidden]) {
+    display: inline-block;
+  }
+}
+
+body.keyboard #vim-mode:not([hidden]) {
+  display: inline-block;
 }
 
 #status {
@@ -424,9 +455,9 @@ main {
     font-size: 16px;
   }
 
-  /* Vim is a desktop power feature; hide it on the cramped phone bar. */
-  #vim-label,
-  #vim-mode,
+  /* The compile-state text is dropped on the cramped phone bar (errors still
+     surface as toasts). Vim is hidden by capability, not width — see the
+     #vim-label rules above. */
   #status {
     display: none;
   }


### PR DESCRIPTION
Two follow-up UX fixes for the browser editor, on top of the mobile/icon/PWA work already merged (#27, #28).

## Keyboard-gated Vim (hide on phones)
Vim only makes sense with a physical keyboard. There is no web API for hardware-keyboard presence (`navigator.keyboard` only exposes layout maps; the VirtualKeyboard API is about the on-screen keyboard), so the toggle is gated on two complementary signals:

- **CSS** `@media (hover: hover) and (pointer: fine)` — a precise pointer + hover implies a mouse/trackpad, hence a keyboard (desktop, laptop, trackpad tablet). Reveals the control with no flash and no JS.
- **Runtime heuristic** (`main.ts`) — a `keydown` for a key an on-screen keyboard rarely emits (Tab/Escape/arrow/function key, or a Ctrl/Alt/Meta combo) adds `body.keyboard` and enables Vim. Catches a tablet with a Bluetooth keyboard, which iPadOS Safari still reports as a coarse/no-hover touch device ([WebKit #209292](https://bugs.webkit.org/show_bug.cgi?id=209292)).

Vim is also no longer *applied* without a keyboard, so a touch device can't get the on-screen keyboard trapped in Vim's normal mode (the preference persists and activates once a keyboard appears).

## Floating preview controls (remove the top toolbar)
- The preview pane's fixed top toolbar is replaced by a translucent **floating pill at the bottom-right of the preview** holding the same controls (zoom −/%/+, fit width, fit height, one/two pages).
- It fades in on hover or focus (CSS) or briefly on activity — scroll/touch/pointer, essential where there is no hover — and fades out when idle (2.2s); switching to the preview tab flashes it once. `prefers-reduced-motion` disables the transition.
- Removing the top strip reclaims it for the preview and fixes the bottom bar in preview mode on mobile.

## Bottom-bar centering
The bottom-bar buttons are vertically centred (verified < 1px offset).

## Verification
`npm run build` (tsc + vite) is clean. `scripts/verify-ui.mjs` (run as an emulated touch device) covers the Vim keyboard gate (hidden with no keyboard, shown after a hardware keystroke), bottom-bar centering offsets, plus the existing icon/PWA/mobile-layout checks. No new npm dependencies, so the flake's `npmDepsHash` is unchanged.

https://claude.ai/code/session_01H9VeSL4TjQisif1jrYPicH

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9VeSL4TjQisif1jrYPicH)_