### PR TITLE
web: fix bottom-bar taps stolen by the logo input overlay on mobile

### DIFF
--- a/web/scripts/verify-ui.mjs
+++ b/web/scripts/verify-ui.mjs
@@ -214,6 +214,23 @@ console.log("MOBILE_EDITOR (editor only):", JSON.stringify(mobileEditor));
 console.log("MOBILE_NO_HSCROLL:", mobileNoHScroll);
 console.log("MOBILE_BOTTOMBAR_CENTER_OFFSET_PX:", (await barCenterOffset()).toFixed(2));
 
+// In preview mode the floating controls and the (invisible) logo file input must
+// not cover the bottom-bar actions: a tap on each must land on that button, not
+// be swallowed by a neighbour (the logo overlay used to steal Download's taps).
+await page.click("#show-preview");
+await page.evaluate(() => document.getElementById("preview-controls").classList.add("show"));
+await new Promise((r) => setTimeout(r, 100));
+const hitTest = await page.evaluate(() => {
+  const at = (id) => {
+    const b = document.getElementById(id).getBoundingClientRect();
+    const t = document.elementFromPoint(b.left + b.width / 2, b.top + b.height / 2);
+    return t?.closest("#" + id) ? "ok" : "covered-by:" + (t?.id || t?.tagName);
+  };
+  return { download: at("download"), reset: at("reset"), "logo-label": at("logo-label") };
+});
+console.log("MOBILE_PREVIEW_BAR_HITTEST:", JSON.stringify(hitTest));
+await page.click("#show-editor");
+
 await page.setViewport({ width: 1200, height: 800 }); // desktop
 await new Promise((r) => setTimeout(r, 150));
 const wide = { toggle: await visible("#view-toggle"), editor: await visible("#editor"), preview: await visible("#preview") };

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -273,6 +273,10 @@ main {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  /* Above the floating preview controls (z-index 5) so its buttons always win
+     taps even if the two ever overlap. */
+  position: relative;
+  z-index: 10;
   padding: 0.3rem 1rem;
   /* Keep clear of a notched phone's home indicator in standalone mode. */
   padding-bottom: max(0.3rem, env(safe-area-inset-bottom));
@@ -362,19 +366,24 @@ body.keyboard #vim-mode:not([hidden]) {
   opacity: 1;
 }
 
-/* The logo control is a file input styled as an icon button; the real input is
-   hidden but still focusable and labelled (its .sr-only text names it). */
+/* The logo control is a file input styled as an icon button. The input is
+   visually hidden (sr-only) rather than stretched over the button — a
+   full-size invisible <input type=file> overlay can capture taps on the
+   neighbouring buttons on iOS. The wrapping <label> still opens the picker. */
 #logo-label {
   position: relative;
 }
 
 #logo-label input {
   position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  cursor: pointer;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 #logo-label:focus-within {
@@ -392,9 +401,13 @@ body.keyboard #vim-mode:not([hidden]) {
   flex-direction: column;
   gap: 0.5rem;
   max-width: min(32rem, 90vw);
+  /* The container spans a region but only the toasts themselves are interactive;
+     without this it would swallow taps on the controls beneath it. */
+  pointer-events: none;
 }
 
 .toast {
+  pointer-events: auto;
   display: flex;
   align-items: flex-start;
   gap: 0.5rem;


### PR DESCRIPTION
In preview mode on mobile, tapping Download (or Reset) could open the logo file picker instead. The logo control's <input type=file> was stretched over its button with position:absolute; inset:0, and on iOS that invisible overlay can capture taps on neighbouring buttons. Hide the input sr-only instead and let the wrapping <label> open the picker — no overlay, no stolen taps.

Also harden the bottom bar generally: restore pointer-events:none on the (often empty) toast container so it never swallows taps beneath it, and give #statusbar position:relative + z-index so its buttons always win over the floating preview controls if they ever overlap.

verify-ui.mjs gains a preview-mode hit-test: a tap at each bottom-bar action's centre must land on that button, not a neighbour.

https://claude.ai/code/session_01H9VeSL4TjQisif1jrYPicH