### PR TITLE
Add no-gap (compact paragraph) style to the typst pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,73 @@ make help                               # Show all targets
 
 PDFs depend on `sfs-2487-2024.cls`, so editing the class triggers rebuilds.
 
+### Verifying output against the spec (all three pipelines)
+
+The class is the reference implementation; the markdown→LaTeX (pandoc) and
+markdown→typst (`web/`) pipelines must reproduce its layout. Tools come from
+nix ad-hoc (`nix shell --inputs-from . nixpkgs#<pkg>`), so nothing needs to be
+in `devenv.nix`.
+
+**Reading the spec PDF.** `pdftotext -layout SFS-2487-2024.pdf -` puts the body
+text in a deep right-hand column and repeats an SFS Online watermark on every
+page; strip it before reading clause text:
+
+```bash
+nix shell nixpkgs#poppler-utils --command pdftotext -layout SFS-2487-2024.pdf - \
+  | grep -viE 'Lataaja|kirjasto käyttöön|ladattu SFS Online' | sed -E 's/^ +//'
+```
+
+The authoritative numbers (clauses 6.4.2–6.4.3, 5.2, Taulukko 2): left & bottom
+margin 2 cm, other margins ≥ 1 cm, basic column 2,3 cm, body text 2,3 cm from
+the left margin (max line width 15,7 cm), basic metadata 9,2 cm from the left
+margin, body font 11–12 pt, line spacing 1,1–1,2, paragraph gap ≥ 10 pt, main
+title bold and 2–4 pt larger than body. Metadata order: doctype (bold), date,
+docid, confidentiality.
+
+**Measuring a PDF.** `pdftotext -bbox` emits per-*word* boxes (x-positions);
+`mutool draw -F stext` (nixpkgs#mupdf-headless) emits per-*line* boxes plus font
+name and size. Useful one-liners:
+
+```bash
+# x-grid tally — expect 56.69 pt (20 mm margin), 121.9 pt (43 mm body),
+# 317.5 pt (112 mm metadata):
+pdftotext -bbox -f 1 -l 1 file.pdf - | grep -oE 'xMin="[0-9.]+"' \
+  | sort -t'"' -k2 -n | uniq -c | sort -rn | head
+# font name + size per run (body 10.9091 pt = the 11pt class's \@xipt; title +3pt):
+mutool draw -F stext -o - file.pdf | grep -oE 'font name="[^"]+" size="[0-9.]+"' \
+  | sort | uniq -c | sort -rn
+# line-baseline deltas — within-paragraph leading ≈ 13.15 pt, paragraph gap
+# adds ≈ 11.6 pt on top (≈ 24.75 pt baseline-to-baseline):
+mutool draw -F stext -o - file.pdf | grep -oE '<line bbox="[0-9.]+ [0-9.]+' \
+  | sed -E 's/<line bbox=.[0-9.]+ //' \
+  | awk '{if(p!=""){d=$1-p; if(d>0)printf "%.1f d=%.2f\n",$1,d}; p=$1}'
+```
+
+**Compiling the typst pipeline outside the browser.** The web editor runs
+typst.ts in-browser, but the same `.typ` compiles with the nix `typst` CLI for
+measurement. Convert markdown with the shared porter, then compile against the
+class's root and the bundled metric-compatible fonts:
+
+```bash
+( cd web && nix shell --inputs-from .. nixpkgs#nodejs --command npm install )  # once
+cd web && nix shell --inputs-from .. nixpkgs#nodejs --command \
+  node --experimental-strip-types scripts/convert.ts ../examples/markdown/esimerkki-X.md \
+  > src/_tmp.typ
+nix shell --inputs-from .. nixpkgs#typst --command typst compile \
+  --root src --font-path public/fonts src/_tmp.typ /tmp/X-typst.pdf
+rm src/_tmp.typ   # keep the temp out of web/src
+```
+
+`convert.ts` imports the markdown deps, so `npm install` in `web/` is required
+first. The CLI `typst` (≈ 0.14) is a newer engine than the pinned
+`@myriaddreamin/typst.ts` (0.7.0-rc2 ≈ typst 0.13) the editor ships, but layout
+metrics match closely enough for the position/size checks above. The bundled
+`web/public/fonts/texgyre*.otf` are the metric-compatible stand-ins (Heros↔
+Helvetica, Pagella↔Palatino, Cursor↔Courier) the typst module names, so feeding
+them via `--font-path` reproduces the editor's spacing. Note the frontmatter
+`logo:` path is *not* read in the browser pipeline (logos are uploaded), so a
+CLI/LaTeX comparison of a logo document differs in the logo area only.
+
 ### CTAN Packaging
 
 The class is packaged for CTAN with **l3build** (configured in `build.lua`): `l3build ctan` builds the release zips, `l3build tag <version>` syncs the version/date strings across the class and its documentation. See `.claude/skills/latex-packaging.md` for the full release workflow.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -17,6 +17,7 @@ without downloading first.
 | `esimerkki-raportti` | Multi-page report: table of contents (6.10), table with its caption above and a bold header row (6.5.1), footnote (6.9), three heading levels | [PDF](pdf/latex/esimerkki-raportti.pdf) · [source](src/latex/esimerkki-raportti.tex.txt) | [PDF](pdf/markdown/esimerkki-raportti.pdf) · [source](src/markdown/esimerkki-raportti.md.txt) |
 | `esimerkki-kayttoohje` | `sans-serif` manual with captioned figures in the text flow (6.5.2) and numbered step lists | [PDF](pdf/latex/esimerkki-kayttoohje.pdf) · [source](src/latex/esimerkki-kayttoohje.tex.txt) | [PDF](pdf/markdown/esimerkki-kayttoohje.pdf) · [source](src/markdown/esimerkki-kayttoohje.md.txt) |
 | `esimerkki-monospace` | `monospace` memo demonstrating the Courier typewriter font | [PDF](pdf/latex/esimerkki-monospace.pdf) · [source](src/latex/esimerkki-monospace.tex.txt) | [PDF](pdf/markdown/esimerkki-monospace.pdf) · [source](src/markdown/esimerkki-monospace.md.txt) |
+| `esimerkki-muistio` | Memo in the compact `nogap` / `no-gap` paragraph style: consecutive paragraphs set apart by a one-column first-line indent instead of a paragraph gap | [PDF](pdf/latex/esimerkki-muistio.pdf) · [source](src/latex/esimerkki-muistio.tex.txt) | [PDF](pdf/markdown/esimerkki-muistio.pdf) · [source](src/markdown/esimerkki-muistio.md.txt) |
 
 `esimerkki-poytakirja` and `esimerkki-tarjous` replicate the standard's
 own model documents (Liite A and B in SFS 2487:2024), so their output

--- a/examples/latex/esimerkki-muistio.tex
+++ b/examples/latex/esimerkki-muistio.tex
@@ -1,0 +1,58 @@
+\documentclass[nogap]{sfs-2487-2024}
+
+% Muistio tiiviillä, sisennetyllä kappaletyylillä. Vaihtoehto [nogap] erottaa
+% peräkkäiset kappaleet ensimmäisen rivin sisennyksellä kappalevälin sijaan
+% (oletustyylissä kappaleet erotetaan toisistaan kappalevälillä, 6.4.3).
+
+\logo{\includegraphics{logo-organisaatio}}
+\doctype{Muistio}
+\date{3.6.2024}
+\author{Sari Salonen}
+
+\subject{Henkilöstöhallinto}
+\title{Etätyökäytäntöjen päivitys}
+
+\contactinfo{Organisaatio Oy}{%
+  Katuosoite\\
+  Postinumero Postitoimipaikka\\
+  hr@organisaatio.fi}
+
+\begin{document}
+
+\maketitle
+
+\marginlabel{Vastaanottajat}
+
+Esihenkilöt ja henkilöstö
+
+\section{Taustaa}
+
+Nykyiset etätyökäytännöt laadittiin poikkeusolojen aikana, ja ne ovat
+olleet voimassa muuttumattomina kahden vuoden ajan. Käytäntöjen
+toimivuudesta on kertynyt runsaasti kokemusta sekä esihenkilöiltä että
+henkilöstöltä.
+
+Saadun palautteen perusteella käytännöt kaipaavat täsmennyksiä erityisesti
+läsnäolon ja tavoitettavuuden osalta. Tähän muistioon on koottu keskeiset
+muutosehdotukset jatkokäsittelyä varten.
+
+\section{Ehdotetut muutokset}
+
+Etätyötä voi jatkossa tehdä enintään kolmena päivänä viikossa. Vähintään
+kaksi päivää tehdään lähtökohtaisesti työpaikalla, jotta tiimien yhteistyö
+ja uusien työntekijöiden perehdytys säilyvät sujuvina.
+
+Yhteiset kokouspäivät sovitaan tiimeittäin, ja niistä ilmoitetaan
+kalenterissa hyvissä ajoin. Tavoitettavuus työaikana koskee yhtä lailla
+etä- ja lähityötä.
+
+\section{Aikataulu}
+
+Päivitetyt käytännöt otetaan käyttöön seuraavan vuosineljänneksen alusta.
+Esihenkilöt käyvät muutokset läpi tiimeissään ennen niiden voimaantuloa.
+
+\forinformation{Johtoryhmä}
+
+\makecontactinfo
+
+\end{document}

--- a/examples/markdown/esimerkki-muistio.md
+++ b/examples/markdown/esimerkki-muistio.md
@@ -1,0 +1,50 @@
+---
+# Markdown-versio ../latex/esimerkki-muistio.tex-asiakirjasta: muistio
+# tiiviillä, sisennetyllä kappaletyylillä. Ominaisuus "features: [no-gap]"
+# erottaa peräkkäiset kappaleet ensimmäisen rivin sisennyksellä kappalevälin
+# sijaan (oletustyylissä kappaleet erotetaan kappalevälillä, 6.4.3).
+doctype: Muistio
+date: 3.6.2024
+author: Sari Salonen
+subject: Henkilöstöhallinto
+title: Etätyökäytäntöjen päivitys
+logo: ../logo-organisaatio.pdf
+contact:
+  name: Organisaatio Oy
+  lines:
+    - Katuosoite
+    - Postinumero Postitoimipaikka
+    - hr@organisaatio.fi
+forinformation:
+  - Johtoryhmä
+features: [no-gap, no-endmatter-newpage]
+---
+
+Vastaanottajat
+:   Esihenkilöt ja henkilöstö
+
+# Taustaa
+
+Nykyiset etätyökäytännöt laadittiin poikkeusolojen aikana, ja ne ovat
+olleet voimassa muuttumattomina kahden vuoden ajan. Käytäntöjen
+toimivuudesta on kertynyt runsaasti kokemusta sekä esihenkilöiltä että
+henkilöstöltä.
+
+Saadun palautteen perusteella käytännöt kaipaavat täsmennyksiä erityisesti
+läsnäolon ja tavoitettavuuden osalta. Tähän muistioon on koottu keskeiset
+muutosehdotukset jatkokäsittelyä varten.
+
+# Ehdotetut muutokset
+
+Etätyötä voi jatkossa tehdä enintään kolmena päivänä viikossa. Vähintään
+kaksi päivää tehdään lähtökohtaisesti työpaikalla, jotta tiimien yhteistyö
+ja uusien työntekijöiden perehdytys säilyvät sujuvina.
+
+Yhteiset kokouspäivät sovitaan tiimeittäin, ja niistä ilmoitetaan
+kalenterissa hyvissä ajoin. Tavoitettavuus työaikana koskee yhtä lailla
+etä- ja lähityötä.
+
+# Aikataulu
+
+Päivitetyt käytännöt otetaan käyttöön seuraavan vuosineljänneksen alusta.
+Esihenkilöt käyvät muutokset läpi tiimeissään ennen niiden voimaantuloa.

--- a/web/src/md-to-typst.ts
+++ b/web/src/md-to-typst.ts
@@ -89,17 +89,18 @@ function frontmatterToArgs(meta: Record<string, unknown>, opts: ConvertOptions):
   // Class options.
   if (meta.font != null) args.push(`font: ${str(String(meta.font))}`);
   if (meta.fontsize != null) args.push(`fontsize: ${String(meta.fontsize).replace(/pt$/, "")}pt`);
-  // features: [agenda, toc, endmatter-newpage, runin] with a `no-` prefix to
-  // disable; runin defaults on (only the `no-runin` opt-out is meaningful).
+  // features: [agenda, toc, endmatter-newpage, runin, gap] with a `no-` prefix
+  // to disable; runin and gap default on (only the `no-runin` / `no-gap`
+  // opt-outs are meaningful — no-gap switches to the compact run-on style).
   const features = parseFeatures(meta);
-  for (const f of ["agenda", "toc", "endmatter-newpage", "runin"] as const) {
+  for (const f of ["agenda", "toc", "endmatter-newpage", "runin", "gap"] as const) {
     args.push(`${f}: ${features[f] ? "true" : "false"}`);
   }
   return args.join(",\n  ");
 }
 
 function parseFeatures(meta: Record<string, unknown>): Record<string, boolean> {
-  const names = ["agenda", "toc", "endmatter-newpage", "runin"];
+  const names = ["agenda", "toc", "endmatter-newpage", "runin", "gap"];
   for (const n of names) {
     if (meta[n] != null) {
       throw new ConversionError(
@@ -115,7 +116,7 @@ function parseFeatures(meta: Record<string, unknown>): Record<string, boolean> {
     const name = off ? token.slice(3) : token;
     if (!names.includes(name)) {
       throw new ConversionError(
-        `sfs-2487-2024: tuntematon ominaisuus (unknown feature) '${token}' — tuetut (supported): agenda, toc, endmatter-newpage`,
+        `sfs-2487-2024: tuntematon ominaisuus (unknown feature) '${token}' — tuetut (supported): agenda, toc, endmatter-newpage, runin, gap`,
       );
     }
     out[name] = !off;
@@ -124,6 +125,7 @@ function parseFeatures(meta: Record<string, unknown>): Record<string, boolean> {
     out["endmatter-newpage"] = meta.attachments != null || meta.distribution != null || meta.forinformation != null;
   }
   if (out["runin"] === undefined) out["runin"] = true;
+  if (out["gap"] === undefined) out["gap"] = true;
   return out;
 }
 

--- a/web/src/sfs-2487-2024.typ
+++ b/web/src/sfs-2487-2024.typ
@@ -118,6 +118,7 @@
   agenda: false,
   toc: false,
   runin: true,
+  gap: true,
   endmatter-newpage: false,
   body,
 ) = {
@@ -130,7 +131,11 @@
     #strong(doctype) #h(1fr) #context counter(page).display("1 (1)", both: true) \
     #date
     #if docid != none [ \ #docid ]
-    #if confidentiality != none [ \ #confidentiality ]
+    // Confidentiality is set off below the date/docid identification lines. With
+    // no docid the class inserts a blank spacer line first (the \mbox{} in
+    // \sfs@metadatablock), so reproduce it here; with a docid present it follows
+    // directly, as in the class.
+    #if confidentiality != none [#if docid == none [ \ ] \ #confidentiality]
   ]
 
   // The basic metadata block, repeated as the page header on every page; the
@@ -173,7 +178,20 @@
   )
   set text(font: body-font, size: fontsize, lang: "fi", hyphenate: true)
   // linespread 0.9706 in the class → 13.2 pt leading at 11 pt; parskip 11.6 pt.
-  set par(leading: leading, spacing: blockgap, justify: false, first-line-indent: 0pt)
+  // Block style (gap, the default, following 6.4.3): paragraphs separated by a
+  // paragraph gap, no first-line indent. Compact style (no-gap, cls [nogap]):
+  // paragraphs run on with no gap (spacing collapses to one line), a paragraph
+  // that follows another set apart by a one-column first-line indent; the first
+  // paragraph after a heading/title/list stays flush (all: false). The
+  // structural paragraph gap stays constant either way — figures, marginlabels
+  // and the end matter set their own block spacing explicitly (as the class
+  // decouples \sfsparskip from \parskip).
+  set par(
+    leading: leading,
+    spacing: if gap { blockgap } else { leading },
+    justify: false,
+    first-line-indent: if gap { 0pt } else { (amount: column, all: false) },
+  )
   set list(marker: [–], indent: 0pt) // Finnish convention: en dash, flush at body indent
   set enum(indent: 0pt)
   set heading(numbering: if agenda { "1.1.1." } else { "1.1.1" })


### PR DESCRIPTION
The compact run-on paragraph style — the class's [nogap] option and the pandoc front end's `no-gap` feature — was missing from the markdown→typst pipeline, so the web editor could not produce it. Add it for parity:

- web/src/sfs-2487-2024.typ: a `gap: true` parameter on sfs-document; the compact style collapses inter-paragraph spacing to one line and sets a one-column first-line indent (first paragraph after a heading/title/list stays flush), mirroring the class's [nogap] branch.
- web/src/md-to-typst.ts: a `gap` feature (default on; `no-gap` opts out), matching pandoc/sfs-2487-2024.lua.

Also fix the metadata block to match the LaTeX reference: insert the blank spacer line before the confidentiality marking when there is no docid (the class's \mbox{} in \sfs@metadatablock).

Add an esimerkki-muistio example pair exercising the compact style, a row in docs/examples.md, and a spec-verification recipe to AGENTS.md (reading the watermarked spec PDF; compiling the typst pipeline with the nix CLI; x-grid / font-size / line-baseline measurements).

Verified LaTeX↔typst on esimerkki-muistio: first paragraph flush at 121.9 pt, following paragraphs indented to 187.1 pt, consecutive-paragraph baseline delta 13.15 pt (no parskip) in both pipelines.